### PR TITLE
Static invariant parser updates

### DIFF
--- a/src/IntelligentPlant.Relativity/RelativityParser.cs
+++ b/src/IntelligentPlant.Relativity/RelativityParser.cs
@@ -16,7 +16,7 @@ namespace IntelligentPlant.Relativity {
         /// An <see cref="IRelativityParser"/> that uses the invariant culture and the time zone 
         /// of the local machine.
         /// </summary>
-        public static IRelativityParser InvariantParser { get; } = new Parser(new RelativityParserConfiguration() {
+        public static IRelativityParser Invariant { get; } = new Parser(new RelativityParserConfiguration() {
             CultureInfo = CultureInfo.InvariantCulture,
             BaseTimeSettings = new RelativityBaseTimeSettings(),
             TimeOffsetSettings = new RelativityTimeOffsetSettings()
@@ -26,11 +26,27 @@ namespace IntelligentPlant.Relativity {
         /// An <see cref="IRelativityParser"/> that uses the invariant culture and the UTC time 
         /// zone.
         /// </summary>
-        public static IRelativityParser InvariantUtcParser { get; } = new Parser(new RelativityParserConfiguration() {
+        public static IRelativityParser InvariantUtc { get; } = new Parser(new RelativityParserConfiguration() {
             CultureInfo = CultureInfo.InvariantCulture,
             BaseTimeSettings = new RelativityBaseTimeSettings(),
             TimeOffsetSettings = new RelativityTimeOffsetSettings()
         }, TimeZoneInfo.Utc);
+
+
+        /// <summary>
+        /// An <see cref="IRelativityParser"/> that uses the invariant culture and the time zone 
+        /// of the local machine.
+        /// </summary>
+        [Obsolete("Use RelativityParser.Invariant instead. This property will be removed prior to the final v2.0 release.", false)]
+        public static IRelativityParser InvariantParser => Invariant;
+
+        /// <summary>
+        /// An <see cref="IRelativityParser"/> that uses the invariant culture and the time zone 
+        /// of the local machine.
+        /// </summary>
+        [Obsolete("Use RelativityParser.InvariantUtc instead. This property will be removed prior to the final v2.0 release.", false)]
+        public static IRelativityParser InvariantUtcParser => InvariantUtc;
+
 
         /// <summary>
         /// The <see cref="IRelativityParser"/> for the current asynchronous control flow.
@@ -64,10 +80,10 @@ namespace IntelligentPlant.Relativity {
         /// <seealso cref="AsyncLocal{T}"/>
         public static IRelativityParser Current {
             get {
-                return s_current.Value ?? InvariantParser;
+                return s_current.Value ?? Invariant;
             }
             set {
-                s_current.Value = value ?? InvariantParser;
+                s_current.Value = value ?? Invariant;
             }
         }
 

--- a/src/IntelligentPlant.Relativity/RelativityParserFactory.cs
+++ b/src/IntelligentPlant.Relativity/RelativityParserFactory.cs
@@ -105,10 +105,10 @@ namespace IntelligentPlant.Relativity {
             // For local or UTC time zones, we can use the built-in invariant parsers. Otherwise,
             // we will clone the local invariant parser with a new time zone.
             return timeZone.Equals(TimeZoneInfo.Local)
-                ? RelativityParser.InvariantParser
+                ? RelativityParser.Invariant
                 : timeZone.Equals(TimeZoneInfo.Utc)
-                    ? RelativityParser.InvariantUtcParser
-                    : Clone(RelativityParser.InvariantParser, null, timeZone);
+                    ? RelativityParser.InvariantUtc
+                    : Clone(RelativityParser.Invariant, null, timeZone);
         }
 
 


### PR DESCRIPTION
This PR adds `RelativityParser.Invariant` and `RelativityParser.InvariantUtc` properties and marks the existing `RelativityParser.InvariantParser` and `RelativityParser.InvariantUtcParser` properties as obsolete.

The newer property names are less clumsy and align with the naming convention used in the `RelativityParser.Current` property.