### PR TITLE
Extension method updates

### DIFF
--- a/src/IntelligentPlant.Relativity/RelativityParser.cs
+++ b/src/IntelligentPlant.Relativity/RelativityParser.cs
@@ -34,21 +34,6 @@ namespace IntelligentPlant.Relativity {
 
 
         /// <summary>
-        /// An <see cref="IRelativityParser"/> that uses the invariant culture and the time zone 
-        /// of the local machine.
-        /// </summary>
-        [Obsolete("Use RelativityParser.Invariant instead. This property will be removed prior to the final v2.0 release.", false)]
-        public static IRelativityParser InvariantParser => Invariant;
-
-        /// <summary>
-        /// An <see cref="IRelativityParser"/> that uses the invariant culture and the time zone 
-        /// of the local machine.
-        /// </summary>
-        [Obsolete("Use RelativityParser.InvariantUtc instead. This property will be removed prior to the final v2.0 release.", false)]
-        public static IRelativityParser InvariantUtcParser => InvariantUtc;
-
-
-        /// <summary>
         /// The <see cref="IRelativityParser"/> for the current asynchronous control flow.
         /// </summary>
         private static readonly AsyncLocal<IRelativityParser> s_current = new AsyncLocal<IRelativityParser>();

--- a/src/IntelligentPlant.Relativity/RelativityParserExtensions.cs
+++ b/src/IntelligentPlant.Relativity/RelativityParserExtensions.cs
@@ -109,7 +109,7 @@ namespace IntelligentPlant.Relativity {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="parser"/> is <see langword="null"/>.
         /// </exception>
-        public static bool IsValidTimestamp(this IRelativityParser parser, string dateString) {
+        public static bool IsValidDateTime(this IRelativityParser parser, string dateString) {
             if (parser == null) {
                 throw new ArgumentNullException(nameof(parser));
             }
@@ -132,7 +132,7 @@ namespace IntelligentPlant.Relativity {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="parser"/> is <see langword="null"/>.
         /// </exception>
-        public static bool IsValidDuration(this IRelativityParser parser, string durationString) {
+        public static bool IsValidTimeSpan(this IRelativityParser parser, string durationString) {
             if (parser == null) {
                 throw new ArgumentNullException(nameof(parser));
             }

--- a/src/IntelligentPlant.Relativity/RelativityStringExtensions.cs
+++ b/src/IntelligentPlant.Relativity/RelativityStringExtensions.cs
@@ -236,5 +236,39 @@ namespace System {
             return (parser ?? RelativityParser.Current).ConvertToTimeSpan(durationString);
         }
 
+
+        /// <summary>
+        /// Tests if the string is a valid absolute or relative timestamp.
+        /// </summary>
+        /// <param name="dateString">
+        ///   The date string.
+        /// </param>
+        /// <param name="parser">
+        ///   The parser.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the date string is valid; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool IsValidDateTime(this string dateString, IRelativityParser? parser) {
+            return (parser ?? RelativityParser.Current).IsValidDateTime(dateString);
+        }
+
+
+        /// <summary>
+        /// Tests if the string is a valid time span literal or Relativity duration.
+        /// </summary>
+        /// <param name="durationString">
+        ///   The duration string.
+        /// </param>
+        /// <param name="parser">
+        ///   The parser.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the duration string is valid; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool IsValidTimeSpan(this string durationString, IRelativityParser? parser) {
+            return (parser ?? RelativityParser.Current).IsValidTimeSpan(durationString);
+        }
+
     }
 }


### PR DESCRIPTION
This PR makes the following breaking changes:

* Deprecated `RelativityParser.InvariantParser` and `RelativityParser.InvariantUtcParser` properties have been removed.
* `RelativityParserExtensions.IsValidTimestamp` and `RelativityParserExtensions.IsValidDuration` have been renamed to `RelativityParserExtensions.IsValidDateTime` and `RelativityParserExtensions.IsValidTimeSpan` respectively.

The PR also adds new `IsValidDateTime` and `IsValidTimeSpan` extension methods for strings.