### PR TITLE
Add support for IANA time zones

### DIFF
--- a/src/IntelligentPlant.Relativity.Owin/CookieTimeZoneProvider.cs
+++ b/src/IntelligentPlant.Relativity.Owin/CookieTimeZoneProvider.cs
@@ -37,16 +37,7 @@ namespace IntelligentPlant.Relativity.Owin {
 
         /// <inheritdoc/>
         public override Task<TimeZoneInfo?> GetTimeZoneAsync(IOwinContext context) {
-            var tzRaw = context.Request.Cookies[CookieName];
-            if (!string.IsNullOrWhiteSpace(tzRaw)) {
-                try {
-                    var tz = TimeZoneInfo.FindSystemTimeZoneById(tzRaw!);
-                    return Task.FromResult<TimeZoneInfo?>(tz);
-                }
-                catch { }
-            }
-
-            return Task.FromResult<TimeZoneInfo?>(null);
+            return Task.FromResult(GetTimeZoneById(context.Request.Cookies[CookieName]));
         }
 
 

--- a/src/IntelligentPlant.Relativity.Owin/IntelligentPlant.Relativity.Owin.csproj
+++ b/src/IntelligentPlant.Relativity.Owin/IntelligentPlant.Relativity.Owin.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Owin" Version="4.2.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="TimeZoneConverter" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IntelligentPlant.Relativity.Owin/QueryStringTimeZoneProvider.cs
+++ b/src/IntelligentPlant.Relativity.Owin/QueryStringTimeZoneProvider.cs
@@ -37,16 +37,7 @@ namespace IntelligentPlant.Relativity.Owin {
 
         /// <inheritdoc/>
         public override Task<TimeZoneInfo?> GetTimeZoneAsync(IOwinContext context) {
-            var tzRaw = context.Request.Query[QueryStringKey];
-            if (!string.IsNullOrWhiteSpace(tzRaw)) {
-                try {
-                    var tz = TimeZoneInfo.FindSystemTimeZoneById(tzRaw!);
-                    return Task.FromResult<TimeZoneInfo?>(tz);
-                }
-                catch { }
-            }
-
-            return Task.FromResult<TimeZoneInfo?>(null);
+            return Task.FromResult(GetTimeZoneById(context.Request.Query[QueryStringKey]));
         }
 
     }

--- a/src/IntelligentPlant.Relativity.Owin/RequestHeaderTimeZoneProvider.cs
+++ b/src/IntelligentPlant.Relativity.Owin/RequestHeaderTimeZoneProvider.cs
@@ -60,8 +60,10 @@ namespace IntelligentPlant.Relativity.Owin {
 
                 foreach (var item in tzHeaderVals.OrderByDescending(x => x.Quality)) {
                     try {
-                        var tz = TimeZoneInfo.FindSystemTimeZoneById(item.Value!);
-                        return Task.FromResult<TimeZoneInfo?>(tz);
+                        var tz = GetTimeZoneById(item.Value!);
+                        if (tz != null) {
+                            return Task.FromResult<TimeZoneInfo?>(tz);
+                        }
                     }
                     catch { }
                 }

--- a/src/IntelligentPlant.Relativity.Owin/TimeZoneProvider.cs
+++ b/src/IntelligentPlant.Relativity.Owin/TimeZoneProvider.cs
@@ -28,5 +28,33 @@ namespace IntelligentPlant.Relativity.Owin {
         /// </returns>
         public abstract Task<TimeZoneInfo?> GetTimeZoneAsync(IOwinContext context);
 
+
+        /// <summary>
+        /// Gets a time zone by its IANA or Windows ID.
+        /// </summary>
+        /// <param name="timeZoneId">
+        ///   The time zone ID.
+        /// </param>
+        /// <returns>
+        ///   The time zone, or <see langword="null"/> if the time zone ID is not valid.
+        /// </returns>
+        /// <remarks>
+        ///   This method uses <see cref="TimeZoneConverter.TZConvert"/> to resolve the time zone. 
+        ///   Please refer to <a href="https://github.com/mattjohnsonpint/TimeZoneConverter"></a> for more 
+        ///   information about how time zones are resolved.
+        /// </remarks>
+        protected TimeZoneInfo? GetTimeZoneById(string? timeZoneId) {
+            if (string.IsNullOrWhiteSpace(timeZoneId)) {
+                return null;
+            }
+
+            try {
+                return TimeZoneConverter.TZConvert.GetTimeZoneInfo(timeZoneId!);
+            }
+            catch (TimeZoneNotFoundException) {
+                return null;
+            }
+        }
+
     }
 }

--- a/src/IntelligentPlant.Relativity.Owin/UserClaimTimeZoneProvider.cs
+++ b/src/IntelligentPlant.Relativity.Owin/UserClaimTimeZoneProvider.cs
@@ -44,15 +44,7 @@ namespace IntelligentPlant.Relativity.Owin {
             }
 
             var claim = context.Authentication.User.FindFirst(ClaimType);
-            if (!string.IsNullOrWhiteSpace(claim?.Value)) {
-                try {
-                    var tz = TimeZoneInfo.FindSystemTimeZoneById(claim!.Value);
-                    return Task.FromResult<TimeZoneInfo?>(tz);
-                }
-                catch { }
-            }
-
-            return Task.FromResult<TimeZoneInfo?>(null);
+            return Task.FromResult(GetTimeZoneById(claim?.Value));
         }
     }
 }


### PR DESCRIPTION
Adds support for IANA time zones to IntelligentPlant.Relativity.Owin. The TimeZoneConverter library is used to provide conversion from IANA time zones to Windows time zones.

IANA support is already built into the ASP.NET Core middleware via the .NET BCL for modern .NET versions.