### PR TITLE
Request header time zone provider fixes/improvements

### DIFF
--- a/examples/OwinExample/Logging.cs
+++ b/examples/OwinExample/Logging.cs
@@ -1,0 +1,92 @@
+﻿using System.Diagnostics;
+
+using Microsoft.Owin.Logging;
+
+namespace OwinExample {
+
+    internal class OwinLoggerFactory : ILoggerFactory {
+
+        private readonly Microsoft.Extensions.Logging.ILoggerFactory _factory;
+
+        public OwinLoggerFactory(Microsoft.Extensions.Logging.ILoggerFactory factory) {
+            _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+        }
+
+        public ILogger Create(string name) {
+            return new OwinLogger(_factory.CreateLogger(name));
+        }
+
+        private class OwinLogger : ILogger {
+
+            private readonly Microsoft.Extensions.Logging.ILogger _logger;
+
+            public OwinLogger(Microsoft.Extensions.Logging.ILogger logger) {
+                _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
+            }
+
+            public bool WriteCore(TraceEventType eventType, int eventId, object state, Exception exception, Func<object, Exception, string> formatter) {
+                bool TryGetMessage(out string message) {
+                    message = formatter?.Invoke(state, exception)!;
+                    return message != null;
+                };
+
+                string msg;
+
+                switch (eventType) {
+                    case TraceEventType.Critical:
+                        if (!_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Critical)) {
+                            return false;
+                        }
+                        if (TryGetMessage(out msg)) {
+                            Microsoft.Extensions.Logging.LoggerExtensions.LogCritical(_logger, eventId, exception, msg);
+                        }
+                        break;
+                    case TraceEventType.Error:
+                        if (!_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Error)) {
+                            return false;
+                        }
+                        if (TryGetMessage(out msg)) {
+                            Microsoft.Extensions.Logging.LoggerExtensions.LogError(_logger, eventId, exception, msg);
+                        }
+                        break;
+                    case TraceEventType.Warning:
+                        if (!_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Warning)) {
+                            return false;
+                        }
+                        if (TryGetMessage(out msg)) {
+                            Microsoft.Extensions.Logging.LoggerExtensions.LogWarning(_logger, eventId, exception, msg);
+                        }
+                        break;
+                    case TraceEventType.Information:
+                        if (!_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Information)) {
+                            return false;
+                        }
+                        if (TryGetMessage(out msg)) {
+                            Microsoft.Extensions.Logging.LoggerExtensions.LogInformation(_logger, eventId, exception, msg);
+                        }
+                        break;
+                    case TraceEventType.Verbose:
+                        if (!_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Trace)) {
+                            return false;
+                        }
+                        if (TryGetMessage(out msg)) {
+                            Microsoft.Extensions.Logging.LoggerExtensions.LogTrace(_logger, eventId, exception, msg);
+                        }
+                        break;
+                    default:
+                        if (!_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug)) {
+                            return false;
+                        }
+                        if (TryGetMessage(out msg)) {
+                            Microsoft.Extensions.Logging.LoggerExtensions.LogDebug(_logger, eventId, exception, msg);
+                        }
+                        break;
+                }
+
+                return true;
+            }
+        }
+
+    }
+
+}

--- a/examples/OwinExample/Program.cs
+++ b/examples/OwinExample/Program.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 using OwinExample;
 
 var builder = Host.CreateDefaultBuilder(args)
+    .ConfigureLogging(logging => logging.ClearProviders().AddConsole().SetMinimumLevel(LogLevel.Trace))
     .ConfigureServices((context, services) => {
         services.AddHostedService<WebServer>();
     });

--- a/examples/OwinExample/WebServer.cs
+++ b/examples/OwinExample/WebServer.cs
@@ -26,7 +26,7 @@ namespace OwinExample {
 
         private void ConfigureWebHost(IAppBuilder app) {
             var factory = new RelativityParserFactory();
-            app.UseRelativity(factory, new QueryStringTimeZoneProvider());
+            app.UseRelativity(factory, new QueryStringTimeZoneProvider(), new RequestHeaderTimeZoneProvider());
 
             app.Use((context, _) => {
                 var timestamp = context.Request.Query["timestamp"];

--- a/examples/OwinExample/WebServer.cs
+++ b/examples/OwinExample/WebServer.cs
@@ -2,11 +2,21 @@
 using IntelligentPlant.Relativity.Owin;
 
 using Microsoft.Extensions.Hosting;
+using Microsoft.Owin.Logging;
 
 using Owin;
 
 namespace OwinExample {
     internal sealed class WebServer : BackgroundService {
+
+        private readonly Microsoft.Extensions.Logging.ILoggerFactory _loggerFactory;
+
+
+        public WebServer(Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) {
+            _loggerFactory = loggerFactory;
+        }
+
+
         protected override async Task ExecuteAsync(CancellationToken stoppingToken) {
             var webHostStartOptions = new Microsoft.Owin.Hosting.StartOptions();
 
@@ -25,6 +35,8 @@ namespace OwinExample {
 
 
         private void ConfigureWebHost(IAppBuilder app) {
+            app.SetLoggerFactory(new OwinLoggerFactory(_loggerFactory));
+
             var factory = new RelativityParserFactory();
             app.UseRelativity(factory, new QueryStringTimeZoneProvider(), new RequestHeaderTimeZoneProvider());
 

--- a/src/IntelligentPlant.Relativity.AspNetCore/RequestHeaderTimeZoneProvider.cs
+++ b/src/IntelligentPlant.Relativity.AspNetCore/RequestHeaderTimeZoneProvider.cs
@@ -39,8 +39,8 @@ namespace IntelligentPlant.Relativity.AspNetCore {
 
         /// <inheritdoc/>
         public override Task<TimeZoneInfo?> GetTimeZoneAsync(HttpContext context) {
-            var tzHeaderValsRaw = new List<string>(context.Request.Headers.GetCommaSeparatedValues(HeaderName));
-            if (tzHeaderValsRaw.Count > 0 && StringWithQualityHeaderValue.TryParseList(tzHeaderValsRaw, out var tzHeaderVals)) {
+            var tzHeaderValsRaw = context.Request.Headers.GetCommaSeparatedValues(HeaderName);
+            if (tzHeaderValsRaw.Length > 0 && StringWithQualityHeaderValue.TryParseList(tzHeaderValsRaw, out var tzHeaderVals)) {
                 foreach (var item in tzHeaderVals.OrderByDescending(x => x.Quality)) {
                     if (item.Value.Value == null) {
                         continue;

--- a/src/IntelligentPlant.Relativity.Owin/RequestHeaderTimeZoneProvider.cs
+++ b/src/IntelligentPlant.Relativity.Owin/RequestHeaderTimeZoneProvider.cs
@@ -44,8 +44,8 @@ namespace IntelligentPlant.Relativity.Owin {
 
         /// <inheritdoc/>
         public override Task<TimeZoneInfo?> GetTimeZoneAsync(IOwinContext context) {
-            var tzHeaderValsRaw = new List<string>(context.Request.Headers.GetCommaSeparatedValues(HeaderName));
-            if (tzHeaderValsRaw.Count > 0) {
+            var tzHeaderValsRaw = context.Request.Headers.GetCommaSeparatedValues(HeaderName);
+            if (tzHeaderValsRaw?.Count > 0) {
                 var tzHeaderVals = new List<StringWithQualityHeaderValue>();
 
                 foreach (var item in tzHeaderValsRaw) {


### PR DESCRIPTION
This PR updates the OWIN and ASP.NET Core request header time zone providers:

* In ASP.NET Core, an unnecessary allocation for a List<T> has been removed.
* In OWIN, the provider no longer throws an exception if the header was not specified.