### PR TITLE
Always use requested culture when returning a parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ var fiFI = new RelativityParserConfiguration() {
         seconds: "S",
         minutes: "M",
         hours: "T",
-        days: "P",
+        days: "VK", // Vuorokausi i.e. a 24-hour period of time.
         weeks: "VI",
         months: "KK",
         years: "V"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Relative timestamps are expressed in the format `base_time [+/- offset]`, where 
 
 > Note that the culture of the parser is also used when parsing offset quantities. For example, when using a parser with the `fi-FI` culture, the parser will expect a comma as a decimal separator when specifying a fractional quantity.
 
-For the default (invariant culture) parser, the following `base_time` values can be used:
+For invariant and English (`en`) culture parsers, the following `base_time` values can be used:
 
 * `NOW` (or `*`) - current time.
 * `SECOND` - start of the current second.
@@ -59,7 +59,7 @@ For the default (invariant culture) parser, the following `base_time` values can
 * `MONTH` - start of the current month.
 * `YEAR` - start of the current year.
 
-The following units can be used in relative timestamps with the default parser. Both whole and fractional quantities are allowed unless otherwise stated:
+The following units can be used in relative timestamps with invariant and English-language parsers. Both whole and fractional quantities are allowed unless otherwise stated:
 
 * `MS` - milliseconds.
 * `S` - seconds.
@@ -96,7 +96,7 @@ The parser will parse literal time spans, as well as duration expressions. Liter
 var timeSpan = parser.ConvertToTimeSpan("3.19:03:27.775");
 ```
 
-Duration expressions are expressed in the same way as an offset on a relative timestamp i.e. a quantity followed by one of the duration keywords defined in the `TimeOffsetSettings` property of the parser. The following units can be used in duration expressions with the default (invariant culture) parser. Both whole and fractional quantities are allowed unless otherwise stated:
+Duration expressions are expressed in the same way as an offset on a relative timestamp i.e. a quantity followed by one of the duration keywords defined in the `TimeOffsetSettings` property of the parser. The following units can be used in duration expressions with invariant and English-language parsers. Both whole and fractional quantities are allowed unless otherwise stated:
 
 * `MS` - milliseconds.
 * `S` - seconds.
@@ -115,11 +115,11 @@ Examples:
 
 # Registering Parsers
 
-A default set of well-known parsers are registered with `RelativityParserFactory` when the factory is created. The [WellKnownParsers.csv](./src/IntelligentPlant.Relativity/WellKnownParsers.csv) file defines the cultures and keywords that are automatically registered.
+A default set of well-known parser configurations are automatically registered with `RelativityParserFactory` when the factory is created. The [WellKnownParsers.csv](./src/IntelligentPlant.Relativity/WellKnownParsers.csv) file defines the cultures and keywords that are registered.
 
 Additional parser configurations can also be passed to the `RelativityParserFactory` constructor; these configurations will override any matching default parser registrations. The invariant culture parsers cannot be overridden.
 
-To register a parser for a given culture, call the `IRelativityParserFactory.TryRegisterParser` method:
+To manually register a parser configuration for a given culture, call the `IRelativityParserFactory.TryRegisterParser` method:
 
 ```csharp
 var fiFI = new RelativityParserConfiguration() {

--- a/src/IntelligentPlant.Relativity/Internal/Parser.cs
+++ b/src/IntelligentPlant.Relativity/Internal/Parser.cs
@@ -18,13 +18,11 @@ namespace IntelligentPlant.Relativity.Internal {
         /// <param name="timeZone">
         ///   The parser time zone.
         /// </param>
-        internal Parser(RelativityParserConfiguration config, TimeZoneInfo? timeZone) : base(
+        internal Parser(RelativityParserConfiguration config, TimeZoneInfo? timeZone) : this(
             config?.CultureInfo!, 
             timeZone ?? TimeZoneInfo.Local, 
             config?.BaseTimeSettings!, 
-            config?.TimeOffsetSettings!,
-            CompileRegex(RegexHelper.CreateRelativeDateTimeRegexPattern(config?.BaseTimeSettings!, config?.TimeOffsetSettings!, config?.CultureInfo!)),
-            CompileRegex(RegexHelper.CreateDurationRegexPattern(config?.TimeOffsetSettings!, config?.CultureInfo!))
+            config?.TimeOffsetSettings!
         ) { }
 
 
@@ -43,41 +41,19 @@ namespace IntelligentPlant.Relativity.Internal {
         /// <param name="timeOffsetSettings">
         ///   The time offset keyword settings.
         /// </param>
-        /// <param name="relativeDateTimeRegex">
-        ///   The regular expression for parsing relative date and time strings.
-        /// </param>
-        /// <param name="durationRegex">
-        ///   The regular expression for parsing duration strings.
-        /// </param>
         internal Parser(
             CultureInfo cultureInfo,
             TimeZoneInfo timeZone,
             RelativityBaseTimeSettings baseTimeSettings,
-            RelativityTimeOffsetSettings timeOffsetSettings,
-            Regex relativeDateTimeRegex,
-            Regex durationRegex
+            RelativityTimeOffsetSettings timeOffsetSettings
         ) : base(
-            cultureInfo,
-            timeZone,
-            baseTimeSettings,
-            timeOffsetSettings,
-            relativeDateTimeRegex,
-            durationRegex
+            cultureInfo ?? throw new ArgumentNullException(nameof(cultureInfo)),
+            timeZone ?? throw new ArgumentNullException(nameof(timeZone)),
+            baseTimeSettings ?? throw new ArgumentNullException(nameof(baseTimeSettings)),
+            timeOffsetSettings ?? throw new ArgumentNullException(nameof(timeOffsetSettings)),
+            RegexHelper.GetOrCreateRelativeDateTimeRegex(baseTimeSettings!, timeOffsetSettings!, cultureInfo!),
+            RegexHelper.GetOrCreateDurationRegex(timeOffsetSettings!, cultureInfo!)
         ) { }
-
-
-        /// <summary>
-        /// Creates a compiled regular expression for the specified pattern.
-        /// </summary>
-        /// <param name="pattern">
-        ///   The pattern.
-        /// </param>
-        /// <returns>
-        ///   The compiled regular expression.
-        /// </returns>
-        private static Regex CompileRegex(string pattern) {
-            return new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled, TimeSpan.FromSeconds(1));
-        }
 
     }
 }

--- a/src/IntelligentPlant.Relativity/Internal/RegexHelper.cs
+++ b/src/IntelligentPlant.Relativity/Internal/RegexHelper.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace IntelligentPlant.Relativity.Internal {
@@ -15,6 +17,12 @@ namespace IntelligentPlant.Relativity.Internal {
         /// </summary>
         private static readonly string[] s_regexSpecialCharacterEscapes = { @"\\", @"\.", @"\$", @"\^", @"\{", @"\[", @"\(", @"\|", @"\)", @"\*", @"\+", @"\?" };
 
+        /// <summary>
+        /// Holds precompiled regular expressions so that we only create an entry once for each 
+        /// combination of culture and keywords.
+        /// </summary>
+        private static readonly ConcurrentDictionary<string, Regex> s_regexCache = new ConcurrentDictionary<string, Regex>(StringComparer.OrdinalIgnoreCase);
+
 
         /// <summary>
         /// Escapes any characters in the specified string that are special characters in regular 
@@ -28,6 +36,81 @@ namespace IntelligentPlant.Relativity.Internal {
         /// </returns>
         private static string EscapeRegexSpecialCharacters(string s) {
             return s_regexSpecialCharacterEscapes.Aggregate(s, (current, specialCharacter) => Regex.Replace(current, specialCharacter, specialCharacter));
+        }
+
+
+        /// <summary>
+        /// Gets or creates a regular expression for parsing durations.
+        /// </summary>
+        /// <param name="timeOffsetSettings">
+        ///   The time offset settings.
+        /// </param>
+        /// <param name="cultureInfo">
+        ///   The culture to use for parsing numbers.
+        /// </param>
+        /// <returns>
+        ///   A regular expression for parsing durations.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="timeOffsetSettings"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="cultureInfo"/> is <see langword="null"/>.
+        /// </exception>
+        internal static Regex GetOrCreateDurationRegex(RelativityTimeOffsetSettings timeOffsetSettings, CultureInfo cultureInfo) {
+            if (timeOffsetSettings == null) {
+                throw new ArgumentNullException(nameof(timeOffsetSettings));
+            }
+            if (cultureInfo == null) {
+                throw new ArgumentNullException(nameof(cultureInfo));
+            }
+
+            // Key consists of the time offset settings and the decimal separator for the culture.
+            var decimalSeparator = cultureInfo.NumberFormat?.NumberDecimalSeparator ?? CultureInfo.InvariantCulture.NumberFormat.NumberDecimalSeparator;
+            var key = $"to:{Convert.ToBase64String(Encoding.UTF8.GetBytes(timeOffsetSettings.ToString()))}:{decimalSeparator}";
+            return s_regexCache.GetOrAdd(key, _ => CompileRegex(CreateDurationRegexPattern(timeOffsetSettings, cultureInfo)));
+        }
+
+
+        /// <summary>
+        /// Gets or creates a regular expression for parsing relative timestamps.
+        /// </summary>
+        /// <param name="baseTimeSettings">
+        ///   The base time settings.
+        /// </param>
+        /// <param name="timeOffsetSettings">
+        ///   The time offset settings.
+        /// </param>
+        /// <param name="cultureInfo">
+        ///   The culture to use for parsing numbers.
+        /// </param>
+        /// <returns>
+        ///   A regular expression for parsing relative timestamps.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="baseTimeSettings"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="timeOffsetSettings"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="cultureInfo"/> is <see langword="null"/>.
+        /// </exception>
+        internal static Regex GetOrCreateRelativeDateTimeRegex(RelativityBaseTimeSettings baseTimeSettings, RelativityTimeOffsetSettings timeOffsetSettings, CultureInfo cultureInfo) {
+            if (baseTimeSettings == null) {
+                throw new ArgumentNullException(nameof(baseTimeSettings));
+            }
+            if (timeOffsetSettings == null) {
+                throw new ArgumentNullException(nameof(timeOffsetSettings));
+            }
+            if (cultureInfo == null) {
+                throw new ArgumentNullException(nameof(cultureInfo));
+            }
+
+            // Key consists of the base time settings, the time offset settings and the decimal separator for the culture.
+            var decimalSeparator = cultureInfo.NumberFormat?.NumberDecimalSeparator ?? CultureInfo.InvariantCulture.NumberFormat.NumberDecimalSeparator;
+            var key = $"bt:{Convert.ToBase64String(Encoding.UTF8.GetBytes(baseTimeSettings.ToString()))}:{Convert.ToBase64String(Encoding.UTF8.GetBytes(timeOffsetSettings.ToString()))}:{decimalSeparator}";
+            return s_regexCache.GetOrAdd(key, _ => CompileRegex(CreateRelativeDateTimeRegexPattern(baseTimeSettings, timeOffsetSettings, cultureInfo)));
         }
 
 
@@ -49,14 +132,7 @@ namespace IntelligentPlant.Relativity.Internal {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="cultureInfo"/> is <see langword="null"/>.
         /// </exception>
-        internal static string CreateDurationRegexPattern(RelativityTimeOffsetSettings timeOffsetSettings, CultureInfo cultureInfo) {
-            if (timeOffsetSettings == null) {
-                throw new ArgumentNullException(nameof(timeOffsetSettings));
-            }
-            if (cultureInfo == null) {
-                throw new ArgumentNullException(nameof(cultureInfo));
-            }
-
+        private static string CreateDurationRegexPattern(RelativityTimeOffsetSettings timeOffsetSettings, CultureInfo cultureInfo) {
             var timeSpanUnits = new[] {
                 timeOffsetSettings.Weeks,
                 timeOffsetSettings.Days,
@@ -87,17 +163,31 @@ namespace IntelligentPlant.Relativity.Internal {
         }
 
 
-        internal static string CreateRelativeDateTimeRegexPattern(RelativityBaseTimeSettings baseTimeSettings, RelativityTimeOffsetSettings timeOffsetSettings, CultureInfo cultureInfo) {
-            if (baseTimeSettings == null) {
-                throw new ArgumentNullException(nameof(baseTimeSettings));
-            }
-            if (timeOffsetSettings == null) {
-                throw new ArgumentNullException(nameof(timeOffsetSettings));
-            }
-            if (cultureInfo == null) {
-                throw new ArgumentNullException(nameof(cultureInfo));
-            }
-            
+        /// <summary>
+        /// Creates a regular expression pattern for parsing relative timestamps.
+        /// </summary>
+        /// <param name="baseTimeSettings">
+        ///   The base time settings.
+        /// </param>
+        /// <param name="timeOffsetSettings">
+        ///   The time offset settings.
+        /// </param>
+        /// <param name="cultureInfo">
+        ///   The culture to use for parsing numbers.
+        /// </param>
+        /// <returns>
+        ///   A regular expression pattern for parsing durations.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="baseTimeSettings"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="timeOffsetSettings"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="cultureInfo"/> is <see langword="null"/>.
+        /// </exception>
+        private static string CreateRelativeDateTimeRegexPattern(RelativityBaseTimeSettings baseTimeSettings, RelativityTimeOffsetSettings timeOffsetSettings, CultureInfo cultureInfo) {
             var baseTimes = new[] {
                 baseTimeSettings.CurrentYear,
                 baseTimeSettings.CurrentMonth,
@@ -159,6 +249,20 @@ namespace IntelligentPlant.Relativity.Internal {
                     ),
                 @"))?\s*$"
             );
+        }
+
+
+        /// <summary>
+        /// Creates a compiled regular expression for the specified pattern.
+        /// </summary>
+        /// <param name="pattern">
+        ///   The pattern.
+        /// </param>
+        /// <returns>
+        ///   The compiled regular expression.
+        /// </returns>
+        private static Regex CompileRegex(string pattern) {
+            return new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled, TimeSpan.FromSeconds(1));
         }
 
     }

--- a/src/IntelligentPlant.Relativity/RelativityBaseTimeSettings.cs
+++ b/src/IntelligentPlant.Relativity/RelativityBaseTimeSettings.cs
@@ -1,4 +1,7 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
 
 namespace IntelligentPlant.Relativity {
 
@@ -122,6 +125,62 @@ namespace IntelligentPlant.Relativity {
             CurrentWeek = string.IsNullOrWhiteSpace(currentWeek) ? null : currentWeek;
             CurrentMonth = string.IsNullOrWhiteSpace(currentMonth) ? null : currentMonth;
             CurrentYear = string.IsNullOrWhiteSpace(currentYear) ? null : currentYear;
+        }
+
+
+        /// <summary>
+        /// Gets the defined keywords.
+        /// </summary>
+        /// <returns>
+        ///   The defined keywords.
+        /// </returns>
+        private IEnumerable<KeyValuePair<string, string>> GetDefinedKeywords() {
+            if (Now != null) {
+                yield return new KeyValuePair<string, string>(nameof(Now), Now);
+            }
+            if (CurrentSecond != null) {
+                yield return new KeyValuePair<string, string>(nameof(CurrentSecond), CurrentSecond);
+            }
+            if (CurrentMinute != null) {
+                yield return new KeyValuePair<string, string>(nameof(CurrentMinute), CurrentMinute);
+            }
+            if (CurrentHour != null) {
+                yield return new KeyValuePair<string, string>(nameof(CurrentHour), CurrentHour);
+            }
+            if (CurrentDay != null) {
+                yield return new KeyValuePair<string, string>(nameof(CurrentDay), CurrentDay);
+            }
+            if (CurrentWeek != null) {
+                yield return new KeyValuePair<string, string>(nameof(CurrentWeek), CurrentWeek);
+            }
+            if (CurrentMonth != null) {
+                yield return new KeyValuePair<string, string>(nameof(CurrentMonth), CurrentMonth);
+            }
+            if (CurrentYear != null) {
+                yield return new KeyValuePair<string, string>(nameof(CurrentYear), CurrentYear);
+            }
+        }
+
+
+        /// <inheritdoc/>
+        public override string ToString() {
+            var sb = new StringBuilder();
+
+            sb.Append("{");
+            var first = true;
+            foreach (var keyword in GetDefinedKeywords()) {
+                if (first) {
+                    first = false;
+                    sb.Append(' ');
+                }
+                else {
+                    sb.Append(", ");
+                }
+                sb.Append($"\"{keyword.Key}\": \"{keyword.Value}\"");
+            }
+            sb.Append(" }");
+
+            return sb.ToString();
         }
 
     }

--- a/src/IntelligentPlant.Relativity/RelativityParserFactory.cs
+++ b/src/IntelligentPlant.Relativity/RelativityParserFactory.cs
@@ -164,7 +164,7 @@ namespace IntelligentPlant.Relativity {
                 ci = ci.Parent;
             }
 
-            return GetInvariantParser(timeZone);
+            return Clone(RelativityParser.InvariantUtc, cultureInfo, timeZone);
         }
 
 

--- a/src/IntelligentPlant.Relativity/RelativityTimeOffsetSettings.cs
+++ b/src/IntelligentPlant.Relativity/RelativityTimeOffsetSettings.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Text;
 
 namespace IntelligentPlant.Relativity {
 
@@ -127,6 +129,62 @@ namespace IntelligentPlant.Relativity {
             if (timeSpanUnits.All(x => x == null)) {
                 throw new ArgumentException(Resources.Error_AtLeastOneTimeSpanUnitIsRequired);
             }
+        }
+
+
+        /// <summary>
+        /// Gets the defined keywords.
+        /// </summary>
+        /// <returns>
+        ///   The defined keywords.
+        /// </returns>
+        private IEnumerable<KeyValuePair<string, string>> GetDefinedKeywords() {
+            if (Milliseconds != null) {
+                yield return new KeyValuePair<string, string>(nameof(Milliseconds), Milliseconds);
+            }
+            if (Seconds != null) {
+                yield return new KeyValuePair<string, string>(nameof(Seconds), Seconds);
+            }
+            if (Minutes != null) {
+                yield return new KeyValuePair<string, string>(nameof(Minutes), Minutes);
+            }
+            if (Hours != null) {
+                yield return new KeyValuePair<string, string>(nameof(Hours), Hours);
+            }
+            if (Days != null) {
+                yield return new KeyValuePair<string, string>(nameof(Days), Days);
+            }
+            if (Weeks != null) {
+                yield return new KeyValuePair<string, string>(nameof(Weeks), Weeks);
+            }
+            if (Months != null) {
+                yield return new KeyValuePair<string, string>(nameof(Months), Months);
+            }
+            if (Years != null) {
+                yield return new KeyValuePair<string, string>(nameof(Years), Years);
+            }
+        }
+
+
+        /// <inheritdoc/>
+        public override string ToString() {
+            var sb = new StringBuilder();
+
+            sb.Append("{");
+            var first = true;
+            foreach (var keyword in GetDefinedKeywords()) {
+                if (first) {
+                    first = false;
+                    sb.Append(' ');
+                }
+                else {
+                    sb.Append(", ");
+                }
+                sb.Append($"\"{keyword.Key}\": \"{keyword.Value}\"");
+            }
+            sb.Append(" }");
+
+            return sb.ToString();
         }
 
     }

--- a/test/IntelligentPlant.Relativity.Test/DateTimeParsingTests.cs
+++ b/test/IntelligentPlant.Relativity.Test/DateTimeParsingTests.cs
@@ -301,23 +301,21 @@ namespace IntelligentPlant.Relativity.Test {
 
 
         [DataTestMethod]
-        [DataRow("", true)] // Should fall back to invariant culture
-        [DataRow("en-US", true)]
-        [DataRow("en-GB", true)]
-        [DataRow("fi-FI", false)] // Should fall back to invariant culture
-        public void RelativeDateTimeWithOffsetShouldBeParsed(string culture, bool verifyParserCulture) {
+        [DataRow("")] // Should fall back to invariant culture
+        [DataRow("en-US")]
+        [DataRow("en-GB")]
+        [DataRow("fi-FI")] // Should use keywords from invariant culture but number formatting from fi-FI
+        public void RelativeDateTimeWithOffsetShouldBeParsed(string culture) {
             var factory = new RelativityParserFactory();
 
             var parser = factory.GetParser(culture);
             Assert.IsNotNull(parser);
 
-            if (verifyParserCulture) {
-                if (string.IsNullOrWhiteSpace(culture)) {
-                    Assert.AreEqual(CultureInfo.InvariantCulture.Name, parser.CultureInfo.Name);
-                }
-                else {
-                    Assert.AreEqual(culture, parser.CultureInfo.Name);
-                }
+            if (string.IsNullOrWhiteSpace(culture)) {
+                Assert.AreEqual(CultureInfo.InvariantCulture.Name, parser.CultureInfo.Name);
+            }
+            else {
+                Assert.AreEqual(culture, parser.CultureInfo.Name);
             }
 
             var baseTimeTypes = new[] { 
@@ -343,23 +341,21 @@ namespace IntelligentPlant.Relativity.Test {
 
 
         [DataTestMethod]
-        [DataRow("", true)] // Should fall back to invariant culture
-        [DataRow("en-US", true)]
-        [DataRow("en-GB", true)]
-        [DataRow("fi-FI", false)] // Should fall back to invariant culture
-        public void DurationShouldBeParsed(string culture, bool verifyCulture) {
+        [DataRow("")] // Should fall back to invariant culture
+        [DataRow("en-US")]
+        [DataRow("en-GB")]
+        [DataRow("fi-FI")] // Should use keywords from invariant culture but number formatting from fi-FI
+        public void DurationShouldBeParsed(string culture) {
             var factory = new RelativityParserFactory();
 
             var parser = factory.GetParser(culture);
             Assert.IsNotNull(parser);
 
-            if (verifyCulture) {
-                if (string.IsNullOrWhiteSpace(culture)) {
-                    Assert.AreEqual(CultureInfo.InvariantCulture.Name, parser.CultureInfo.Name);
-                }
-                else {
-                    Assert.AreEqual(culture, parser.CultureInfo.Name);
-                }
+            if (string.IsNullOrWhiteSpace(culture)) {
+                Assert.AreEqual(CultureInfo.InvariantCulture.Name, parser.CultureInfo.Name);
+            }
+            else {
+                Assert.AreEqual(culture, parser.CultureInfo.Name);
             }
 
             string unparsed;


### PR DESCRIPTION
This PR modifies `RelativityParserFactory` so that, if a parser is requested for a culture that has no registered configuration, the parser that is returned will use the invariant culture base time and time offset keywords, but will use the requested culture for absolute timestamp and relative offset quantity parsing.