### PR TITLE
Time zone providers use ValueTask<T> instead of Task<T>

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,7 @@
     <PackageVersion Include="MSTest.TestFramework" Version="3.6.1" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageVersion Include="TimeZoneConverter" Version="6.1.0" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -44,41 +44,47 @@ Both absolute and relative timestamps can be parsed. Absolute timestamps are par
 var date = parser.ConvertToUtcDateTime("2019-11-15T08:56:25.0901821Z");
 ```
 
-Relative timestamps are expressed in the format `base_time [+/- offset]`, where the `base_time` matches one of the keywords defined in the parser's `BaseTimeSettings` property, and the `offset` is a number followed by one of the duration keywords defined in the parser's `TimeOffsetSettings` property (e.g. `3D` for 3 days when using the invariant culture parser). White space inside the expression is ignored and the parser uses case-insensitive matching against the `base_time` and `offset` values. 
-
-> Note that the culture of the parser is also used when parsing offset quantities. For example, when using a parser with the `fi-FI` culture, the parser will expect a comma as a decimal separator when specifying a fractional quantity.
+Relative timestamps are expressed in the format `base_time [+/- offset]`, where the `base_time` matches one of the keywords defined in the parser's `BaseTimeSettings` property, and the `offset` is a number followed by one of the duration keywords defined in the parser's `TimeOffsetSettings` property (e.g. `3D` for 3 days when using the invariant culture parser). White space inside the expression is ignored and the parser uses case-insensitive matching against the `base_time` and `offset` values
 
 For invariant and English (`en`) culture parsers, the following `base_time` values can be used:
 
-* `NOW` (or `*`) - current time.
-* `SECOND` - start of the current second.
-* `MINUTE` - start of the current minute.
-* `HOUR` - start of the current hour.
-* `DAY` - start of the current day.
-* `WEEK` - start of the current week. The `CultureInfo` for the parser is used to determine what the first day of the week is.
-* `MONTH` - start of the current month.
-* `YEAR` - start of the current year.
+| Keyword | Description | Notes |
+|---------|-------------| ----- |
+| `NOW` (or `*`) | Current time. |
+| `SECOND` | Start of the current second. |
+| `MINUTE` | Start of the current minute. |
+| `HOUR` | Start of the current hour. |
+| `DAY` | Start of the current day. |
+| `WEEK` | Start of the current week. | The `CultureInfo` for the parser is used to determine what the first day of the week is. |
+| `MONTH` | Start of the current month. |
+| `YEAR` | Start of the current year. |
 
-The following units can be used in relative timestamps with invariant and English-language parsers. Both whole and fractional quantities are allowed unless otherwise stated:
+The following units can be used in relative timestamps with invariant and English-language parsers:
 
-* `MS` - milliseconds.
-* `S` - seconds.
-* `M` - minutes.
-* `H` - hours.
-* `D` - days.
-* `W` - weeks.
-* `MO` - months. Fractional quantities are not allowed.
-* `Y` - years. Fractional quantities are not allowed.
+| Keyword | Description | Fractional Quantities Allowed |
+|---------|-------------| ----------------------------- |
+| `MS` | Milliseconds | Yes |
+| `S` | Seconds | Yes |
+| `M` | Minutes | Yes |
+| `H` | Hours | Yes |
+| `D` | Days | Yes |
+| `W` | Weeks | Yes |
+| `MO` | Months | __No__ |
+| `Y` | Years | __No__ |
 
 Examples:
 
-* `NOW + 15S` - current time plus 15 seconds.
-* `*-10y` - current time minus 10 years.
-* `day-0.5d` - start of current day minus 0.5 days (i.e. 12 hours).
-* `MONTH` - start of the current month.
-* `YEAR + 3MO` - start of current year plus 3 calendar months.
+| Example | Description |
+|---------|-------------|
+| `NOW + 15S` | Current time plus 15 seconds. |
+| `*-10y` | Current time minus 10 years. |
+| `day-0.5d` | Start of current day minus 0.5 days (i.e. 12 hours). |
+| `MONTH` | Start of the current month. |
+| `YEAR + 3MO` | Start of current year plus 3 calendar months. |
 
-Base time values are converted to absolute times relative to a given `DateTime` origin. If no origin is specified when parsing a timestamp, the current time for the parser's time zone is used::
+> Note that the culture of the parser is also used when parsing offset quantities. For example, when using a parser with the `fi-FI` culture, the parser will expect a comma as a decimal separator when specifying a fractional quantity.
+
+Base time values are converted to absolute times relative to a given `DateTime` origin. If no origin is specified when parsing a timestamp, the current time for the parser's time zone is used:
 
 ```csharp
 // No origin specified; current time for the parser's time zone is used as the origin.
@@ -96,21 +102,27 @@ The parser will parse literal time spans, as well as duration expressions. Liter
 var timeSpan = parser.ConvertToTimeSpan("3.19:03:27.775");
 ```
 
-Duration expressions are expressed in the same way as an offset on a relative timestamp i.e. a quantity followed by one of the duration keywords defined in the `TimeOffsetSettings` property of the parser. The following units can be used in duration expressions with invariant and English-language parsers. Both whole and fractional quantities are allowed unless otherwise stated:
+Duration expressions are expressed in the same way as an offset on a relative timestamp i.e. a quantity followed by one of the duration keywords defined in the `TimeOffsetSettings` property of the parser. The following units can be used in duration expressions with invariant and English-language parsers.
 
-* `MS` - milliseconds.
-* `S` - seconds.
-* `M` - minutes.
-* `H` - hours.
-* `D` - days.
-* `W` - weeks.
+| Keyword | Description | Fractional Quantities Allowed |
+|---------|-------------| ----------------------------- |
+| `MS` | Milliseconds | Yes |
+| `S` | Seconds | Yes |
+| `M` | Minutes | Yes |
+| `H` | Hours | Yes |
+| `D` | Days | Yes |
+| `W` | Weeks | Yes |
 
 Examples:
 
-* `500ms` - 500 milliseconds.
-* `15S` - 15 seconds.
-* `0.5H` - 0.5 hours (i.e. 30 minutes).
-* `1W` - 1 week.
+| Example | Description |
+|---------|-------------|
+| `500ms` | 500 milliseconds. |
+| `15S` | 15 seconds. |
+| `0.5H` | 0.5 hours (i.e. 30 minutes). |
+| `1W` | 1 week. |
+
+> Note that the culture of the parser is also used when parsing duration expressions. For example, when using a parser with the `fi-FI` culture, the parser will expect a comma as a decimal separator when specifying a fractional quantity.
 
 
 # Registering Parsers

--- a/build/version.json
+++ b/build/version.json
@@ -2,5 +2,5 @@
   "Major": 2,
   "Minor": 0,
   "Patch": 0,
-  "PreRelease": "pre"
+  "PreRelease": ""
 }

--- a/docs/migration-guide-v1-v2.md
+++ b/docs/migration-guide-v1-v2.md
@@ -1,0 +1,42 @@
+# Migrating from v1 to v2
+
+Version 2 of Relativity contains several breaking changes from version 1. This document provides guidance on how to migrate from version 1 to version 2.
+
+
+# Parsers now implement IRelativityParser
+
+The `RelativityParser` class has been made static in v2 and as such cannot be instantiated. Instead, parser instances now implement the new `IRelativityParser` interface which, combined with extension methods defined in the `RelativityParserExtensions` class, provides a similar (but not identical) API surface.
+
+Notable method name changes include:
+
+| v1 | v2 |
+|----|----|
+| `ToUtcDateTime` | `ConvertToUtcDateTime` |
+| `ToTimeSpan` | `ConvertToTimeSpan` |
+
+
+# Parsers are now created using a factory
+
+In v1, parsers were created by calling the static `RelativityParser.TryGetParser` method. This method has been removed in v2, as it did not allow for the easy creation of parsers that used the same culture but different time zones.
+
+In v2, non-default parsers are created using an `IRelativityParserFactory`. The `RelativityParserFactory` class provides a concrete implementation of the `IRelativityParserFactory` interface. The `RelativityParserFactory.Default` property provides access to a default factory instance.
+
+Custom parser configurations are registered using the `IRelativityParserFactory.TryRegisterParser` method.
+
+All `RelativityParserFactory` instances define a set of well-known parser configurations. These are defined in the [WellKnownParsers.csv](../src/IntelligentPlant.Relativity/WellKnownParsers.csv) file. This file is used by the [WellKnownParsers.tt](../src/IntelligentPlant.Relativity/WellKnownParsers.tt) text template file to generate compile-time source that registers the well-known parsers with the factory. Additional parser configurations can be passed to the factory constructor; well-known parser registrations can be replaced using this approach if desired.
+
+
+# RelativityParser.Default has been removed
+
+The `RelativityParser.Default` property has been removed in v2. Instead, the following static properties are defined:
+
+* `RelativityParser.Invariant` - a parser that uses `CultureInfo.InvariantCulture` and the system's local time zone.
+* `RelativityParser.InvariantUtc` - a parser that uses `CultureInfo.InvariantCulture` and UTC.
+* `RelativityParser.Current` - the parser for the current asynchronous context. See below for more details.
+
+
+# RelativityParser.Current is local to the asynchronous control flow
+
+Instead of having to pass a parser instance around in your code, you can now use the `RelativityParser.Current` property to get or set the parser for the current asynchronous context. `RelativityParser.Current` will return `RelativityParser.InvariantUtc` if it has not been explicitly set for the current context.
+
+`RelativityParser.Current` uses [AsyncLocal&lt;T&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.threading.asynclocal-1) to store the parser instance for the current asynchronous context. This means that the parser instance is not shared between different asynchronous contexts (such as pipelines for different HTTP requests).

--- a/src/IntelligentPlant.Relativity.AspNetCore/CookieTimeZoneProvider.cs
+++ b/src/IntelligentPlant.Relativity.AspNetCore/CookieTimeZoneProvider.cs
@@ -33,12 +33,12 @@ namespace IntelligentPlant.Relativity.AspNetCore {
 
 
         /// <inheritdoc/>
-        public override Task<TimeZoneInfo?> GetTimeZoneAsync(HttpContext context) {
+        public override ValueTask<TimeZoneInfo?> GetTimeZoneAsync(HttpContext context) {
             if (context.Request.Cookies.TryGetValue(CookieName, out var tzId) && !string.IsNullOrWhiteSpace(tzId) && TimeZoneInfo.TryFindSystemTimeZoneById(tzId!, out var tz)) {
-                return Task.FromResult<TimeZoneInfo?>(tz);
+                return new ValueTask<TimeZoneInfo?>(tz);
             }
 
-            return Task.FromResult<TimeZoneInfo?>(null);
+            return new ValueTask<TimeZoneInfo?>((TimeZoneInfo?) null);
         }
 
 

--- a/src/IntelligentPlant.Relativity.AspNetCore/IntelligentPlant.Relativity.AspNetCore.csproj
+++ b/src/IntelligentPlant.Relativity.AspNetCore/IntelligentPlant.Relativity.AspNetCore.csproj
@@ -5,7 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Provides extensions methods for registering IntelligentPlant.Relativity services with an ASP.NET Core application.</Description>
-    <GenerateDocumentationFile>string</GenerateDocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +15,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\IntelligentPlant.Relativity.DependencyInjection\IntelligentPlant.Relativity.DependencyInjection.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/IntelligentPlant.Relativity.AspNetCore/QueryStringTimeZoneProvider.cs
+++ b/src/IntelligentPlant.Relativity.AspNetCore/QueryStringTimeZoneProvider.cs
@@ -33,12 +33,12 @@ namespace IntelligentPlant.Relativity.AspNetCore {
 
 
         /// <inheritdoc/>
-        public override Task<TimeZoneInfo?> GetTimeZoneAsync(HttpContext context) {
+        public override ValueTask<TimeZoneInfo?> GetTimeZoneAsync(HttpContext context) {
             if (context.Request.Query.TryGetValue(QueryStringKey, out var tzQs) && !string.IsNullOrWhiteSpace(tzQs) && TimeZoneInfo.TryFindSystemTimeZoneById(tzQs!, out var tz)) {
-                return Task.FromResult<TimeZoneInfo?>(tz);
+                return new ValueTask<TimeZoneInfo?>(tz);
             }
 
-            return Task.FromResult<TimeZoneInfo?>(null);
+            return new ValueTask<TimeZoneInfo?>((TimeZoneInfo?) null);
         }
 
     }

--- a/src/IntelligentPlant.Relativity.AspNetCore/README.md
+++ b/src/IntelligentPlant.Relativity.AspNetCore/README.md
@@ -3,14 +3,17 @@
 This package provides ASP.NET Core middleware for setting `RelativityParser.Current` for an HTTP request. This allows timestamps and durations to be parsed anywhere in the request using `RelativityParser.Current`.
 
 
-# Configuration
+# Getting Started
 
 ## Registering Time Zone Providers
 
-The middleware uses time zone providers (derived from [TimeZoneProvider](./TimeZoneProvider.cs)) to determine the time zone to use when configuring the Relativity parser for the request. Use the extension methods defined in [RelativityBuilderExtensions](./RelativityBuilderExtensions.cs) to register time zone providers for the middleware:
+The middleware uses time zone providers (derived from `TimeZoneProvider`) to determine the time zone to use when configuring the Relativity parser for the request. Use the extension methods defined in `RelativityBuilderExtensions` to register time zone providers for the middleware:
 
 ```csharp
-builder.AddQueryStringTimeZoneProvider()
+services.AddRelativity()
+    // Set time zone using 'tz' query string parameter
+    .AddQueryStringTimeZoneProvider()
+    // Set time zone using 'X-TimeZone' request header
     .AddRequestHeaderTimeZoneProvider();
 ```
 

--- a/src/IntelligentPlant.Relativity.AspNetCore/RelativityMiddleware.cs
+++ b/src/IntelligentPlant.Relativity.AspNetCore/RelativityMiddleware.cs
@@ -118,7 +118,7 @@ namespace IntelligentPlant.Relativity.AspNetCore {
         }
 
 
-        [LoggerMessage(0, LogLevel.Debug, "Relativity parser settings: Culture={culture}, Time Zone={timeZone}")]
+        [LoggerMessage(1, LogLevel.Debug, "Relativity parser settings: Culture={culture}, Time Zone={timeZone}")]
         partial void LogRelativityParserSet(string culture, string timeZone);
 
     }

--- a/src/IntelligentPlant.Relativity.AspNetCore/RequestHeaderTimeZoneProvider.cs
+++ b/src/IntelligentPlant.Relativity.AspNetCore/RequestHeaderTimeZoneProvider.cs
@@ -38,7 +38,7 @@ namespace IntelligentPlant.Relativity.AspNetCore {
 
 
         /// <inheritdoc/>
-        public override Task<TimeZoneInfo?> GetTimeZoneAsync(HttpContext context) {
+        public override ValueTask<TimeZoneInfo?> GetTimeZoneAsync(HttpContext context) {
             var tzHeaderValsRaw = context.Request.Headers.GetCommaSeparatedValues(HeaderName);
             if (tzHeaderValsRaw.Length > 0 && StringWithQualityHeaderValue.TryParseList(tzHeaderValsRaw, out var tzHeaderVals)) {
                 foreach (var item in tzHeaderVals.OrderByDescending(x => x.Quality)) {
@@ -46,13 +46,13 @@ namespace IntelligentPlant.Relativity.AspNetCore {
                         continue;
                     }
                     if (TimeZoneInfo.TryFindSystemTimeZoneById(item.Value.Value, out var tz)) {
-                        return Task.FromResult<TimeZoneInfo?>(tz);
+                        return new ValueTask<TimeZoneInfo?>(tz);
                     }
                 }
             }
 
 
-            return Task.FromResult<TimeZoneInfo?>(null);
+            return new ValueTask<TimeZoneInfo?>((TimeZoneInfo?) null);
         }
 
     }

--- a/src/IntelligentPlant.Relativity.AspNetCore/TimeZoneProvider.cs
+++ b/src/IntelligentPlant.Relativity.AspNetCore/TimeZoneProvider.cs
@@ -23,7 +23,7 @@ namespace IntelligentPlant.Relativity.AspNetCore {
         /// <returns>
         ///   The time zone to use for the request.
         /// </returns>
-        public abstract Task<TimeZoneInfo?> GetTimeZoneAsync(HttpContext context);
+        public abstract ValueTask<TimeZoneInfo?> GetTimeZoneAsync(HttpContext context);
 
     }
 }

--- a/src/IntelligentPlant.Relativity.AspNetCore/UserClaimTimeZoneProvider.cs
+++ b/src/IntelligentPlant.Relativity.AspNetCore/UserClaimTimeZoneProvider.cs
@@ -36,17 +36,17 @@ namespace IntelligentPlant.Relativity.AspNetCore {
 
 
         /// <inheritdoc/>
-        public override Task<TimeZoneInfo?> GetTimeZoneAsync(HttpContext context) {
+        public override ValueTask<TimeZoneInfo?> GetTimeZoneAsync(HttpContext context) {
             if (context.User == null || !context.User.Identities.All(x => x.IsAuthenticated)) {
-                return Task.FromResult<TimeZoneInfo?>(null);
+                return new ValueTask<TimeZoneInfo?>((TimeZoneInfo?) null);
             }
 
             var claim = context.User.FindFirstValue(ClaimType);
             if (string.IsNullOrWhiteSpace(claim) || !TimeZoneInfo.TryFindSystemTimeZoneById(claim, out var tz)) {
-                return Task.FromResult<TimeZoneInfo?>(null);
+                return new ValueTask<TimeZoneInfo?>((TimeZoneInfo?) null);
             }
 
-            return Task.FromResult<TimeZoneInfo?>(tz);
+            return new ValueTask<TimeZoneInfo?>(tz);
         }
 
     }

--- a/src/IntelligentPlant.Relativity.DependencyInjection/IntelligentPlant.Relativity.DependencyInjection.csproj
+++ b/src/IntelligentPlant.Relativity.DependencyInjection/IntelligentPlant.Relativity.DependencyInjection.csproj
@@ -4,8 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <Description>Provides middleware and extensions methods for registering IntelligentPlant.Relativity services with an IServiceCollection.</Description>
+    <Description>Provides extensions methods for registering IntelligentPlant.Relativity services with an IServiceCollection.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +15,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\IntelligentPlant.Relativity\IntelligentPlant.Relativity.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/IntelligentPlant.Relativity.DependencyInjection/README.md
+++ b/src/IntelligentPlant.Relativity.DependencyInjection/README.md
@@ -1,0 +1,34 @@
+# IntelligentPlant.Relativity.DependencyInjection
+
+This package provides extensions for registering Relativity services with Microsoft.Extensions.DependencyInjection.
+
+
+# Getting Started
+
+Use the `AddRelativity()` extension method for `IServiceCollection` to register Relativity services with the dependency injection container and return an `IRelativityBuilder` that can be used to perform additional configuration. For example:
+
+```csharp
+services.AddRelativity().AddParserConfiguration(new RelativityParserConfiguration() {
+    CultureInfo = CultureInfo.GetCultureInfo("fi-FI"),
+    BaseTimeSettings = new RelativityBaseTimeSettings(
+        now: "NYT",
+        currentSecond: "SEKUNTI",
+        currentMinute: "MINUUTTI",
+        currentHour: "TUNTI",
+        currentDay: "PÄIVÄ",
+        currentWeek: "VIIKKO",
+        currentMonth: "KUUKAUSI",
+        currentYear: "VUOSI"
+    ),
+    TimeOffsetSettings = new RelativityTimeOffsetSettings(
+        milliseconds: "MS",
+        seconds: "S",
+        minutes: "M",
+        hours: "T",
+        days: "VK", // Vuorokausi i.e. a 24-hour period of time.
+        weeks: "VI",
+        months: "KK",
+        years: "V"
+    )
+});
+```

--- a/src/IntelligentPlant.Relativity.Owin/CookieTimeZoneProvider.cs
+++ b/src/IntelligentPlant.Relativity.Owin/CookieTimeZoneProvider.cs
@@ -36,8 +36,8 @@ namespace IntelligentPlant.Relativity.Owin {
 
 
         /// <inheritdoc/>
-        public override Task<TimeZoneInfo?> GetTimeZoneAsync(IOwinContext context) {
-            return Task.FromResult(GetTimeZoneById(context.Request.Cookies[CookieName]));
+        public override ValueTask<TimeZoneInfo?> GetTimeZoneAsync(IOwinContext context) {
+            return new ValueTask<TimeZoneInfo?>(GetTimeZoneById(context.Request.Cookies[CookieName]));
         }
 
 

--- a/src/IntelligentPlant.Relativity.Owin/IntelligentPlant.Relativity.Owin.csproj
+++ b/src/IntelligentPlant.Relativity.Owin/IntelligentPlant.Relativity.Owin.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>net48</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
+    <Description>Provides extensions methods for registering IntelligentPlant.Relativity services with a .NET Framework OWIN application.</Description>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +17,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\IntelligentPlant.Relativity\IntelligentPlant.Relativity.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/IntelligentPlant.Relativity.Owin/IntelligentPlant.Relativity.Owin.csproj
+++ b/src/IntelligentPlant.Relativity.Owin/IntelligentPlant.Relativity.Owin.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Owin" />
     <PackageReference Include="System.Net.Http" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" />
     <PackageReference Include="TimeZoneConverter" />
   </ItemGroup>
 

--- a/src/IntelligentPlant.Relativity.Owin/QueryStringTimeZoneProvider.cs
+++ b/src/IntelligentPlant.Relativity.Owin/QueryStringTimeZoneProvider.cs
@@ -36,8 +36,8 @@ namespace IntelligentPlant.Relativity.Owin {
 
 
         /// <inheritdoc/>
-        public override Task<TimeZoneInfo?> GetTimeZoneAsync(IOwinContext context) {
-            return Task.FromResult(GetTimeZoneById(context.Request.Query[QueryStringKey]));
+        public override ValueTask<TimeZoneInfo?> GetTimeZoneAsync(IOwinContext context) {
+            return new ValueTask<TimeZoneInfo?>(GetTimeZoneById(context.Request.Query[QueryStringKey]));
         }
 
     }

--- a/src/IntelligentPlant.Relativity.Owin/README.md
+++ b/src/IntelligentPlant.Relativity.Owin/README.md
@@ -1,0 +1,29 @@
+# IntelligentPlant.Relativity.Owin
+
+This package provides OWIN middleware for setting `RelativityParser.Current` for an HTTP request. This allows timestamps and durations to be parsed anywhere in the request using `RelativityParser.Current`.
+
+
+# Getting Started
+
+The middleware uses time zone providers (derived from `TimeZoneProvider`) to determine the time zone to use when configuring the Relativity parser for the request. Use the extension methods defined in `AppBuilderExtensions` to register the middleware, `IRelativityParserFactory` and the time zone providers to use:
+
+```csharp
+app.UseRelativity(RelativityParserFactory.Default,
+    // Set time zone using 'tz' query string parameter
+    new QueryStringTimeZoneProvider(),
+    // Set time zone using 'X-TimeZone' request header
+    new RequestHeaderTimeZoneProvider());
+```
+
+Unlike the [ASP.NET Core](https://www.nuget.org/packages/IntelligentPlant.Relativity.AspNetCore) package, the time zone providers are always run in the order that they are specified. The first time zone provider that returns a valid time zone will be used. If no time zone provider returns a valid time zone, UTC will be used.
+
+Note that OWIN does not have built-in capababilities for setting `CultureInfo.CurrentCulture` or `CultureInfo.CurrentUICulture` for the current request. Therefore, you will need to set these manually in the application pipeline prior to the Relativity middleware if you want to allow culture-specific Relativity parsers to be used based on e.g. the `Accept-Language` header specified by the calling user agent.
+
+
+# Using the Parser
+
+You can access the parser for the current request using `RelativityParser.Current`. For example:
+
+```csharp
+var dt = RelativityParser.Current.ConvertToUtcDateTime("DAY+6H");
+```

--- a/src/IntelligentPlant.Relativity.Owin/RequestHeaderTimeZoneProvider.cs
+++ b/src/IntelligentPlant.Relativity.Owin/RequestHeaderTimeZoneProvider.cs
@@ -43,7 +43,7 @@ namespace IntelligentPlant.Relativity.Owin {
 
 
         /// <inheritdoc/>
-        public override Task<TimeZoneInfo?> GetTimeZoneAsync(IOwinContext context) {
+        public override ValueTask<TimeZoneInfo?> GetTimeZoneAsync(IOwinContext context) {
             var tzHeaderValsRaw = context.Request.Headers.GetCommaSeparatedValues(HeaderName);
             if (tzHeaderValsRaw?.Count > 0) {
                 var tzHeaderVals = new List<StringWithQualityHeaderValue>();
@@ -62,14 +62,14 @@ namespace IntelligentPlant.Relativity.Owin {
                     try {
                         var tz = GetTimeZoneById(item.Value!);
                         if (tz != null) {
-                            return Task.FromResult<TimeZoneInfo?>(tz);
+                            return new ValueTask<TimeZoneInfo?>(tz);
                         }
                     }
                     catch { }
                 }
             }
 
-            return Task.FromResult<TimeZoneInfo?>(null);
+            return new ValueTask<TimeZoneInfo?>((TimeZoneInfo?) null);
         }
 
     }

--- a/src/IntelligentPlant.Relativity.Owin/TimeZoneProvider.cs
+++ b/src/IntelligentPlant.Relativity.Owin/TimeZoneProvider.cs
@@ -26,7 +26,7 @@ namespace IntelligentPlant.Relativity.Owin {
         /// <returns>
         ///   The time zone to use for the request.
         /// </returns>
-        public abstract Task<TimeZoneInfo?> GetTimeZoneAsync(IOwinContext context);
+        public abstract ValueTask<TimeZoneInfo?> GetTimeZoneAsync(IOwinContext context);
 
 
         /// <summary>

--- a/src/IntelligentPlant.Relativity.Owin/UserClaimTimeZoneProvider.cs
+++ b/src/IntelligentPlant.Relativity.Owin/UserClaimTimeZoneProvider.cs
@@ -38,13 +38,13 @@ namespace IntelligentPlant.Relativity.Owin {
 
 
         /// <inheritdoc/>
-        public override Task<TimeZoneInfo?> GetTimeZoneAsync(IOwinContext context) {
+        public override ValueTask<TimeZoneInfo?> GetTimeZoneAsync(IOwinContext context) {
             if (context.Authentication.User == null || !context.Authentication.User.Identities.All(x => x.IsAuthenticated)) {
-                return Task.FromResult<TimeZoneInfo?>(null);
+                return new ValueTask<TimeZoneInfo?>((TimeZoneInfo?) null);
             }
 
             var claim = context.Authentication.User.FindFirst(ClaimType);
-            return Task.FromResult(GetTimeZoneById(claim?.Value));
+            return new ValueTask<TimeZoneInfo?>(GetTimeZoneById(claim?.Value));
         }
     }
 }

--- a/src/IntelligentPlant.Relativity/IRelativityParserFactory.cs
+++ b/src/IntelligentPlant.Relativity/IRelativityParserFactory.cs
@@ -27,11 +27,18 @@ namespace IntelligentPlant.Relativity {
 
 
         /// <summary>
-        /// Tries to register a default parser
+        /// Tries to register a parser
         /// </summary>
-        /// <param name="parser"></param>
-        /// <param name="replaceExisting"></param>
-        /// <returns></returns>
+        /// <param name="parser">
+        ///   The parser configuration.
+        /// </param>
+        /// <param name="replaceExisting">
+        ///   Specifies if the parser should replace an existing parser with the same culture.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the parser was successfully registered; otherwise, 
+        ///   <see langword="false"/>.
+        /// </returns>
         bool TryRegisterParser(RelativityParserConfiguration parser, bool replaceExisting = false);
 
     }

--- a/src/IntelligentPlant.Relativity/IntelligentPlant.Relativity.csproj
+++ b/src/IntelligentPlant.Relativity/IntelligentPlant.Relativity.csproj
@@ -6,6 +6,7 @@
     <Description>Parses absolute and relative timestamps and durations.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -44,6 +45,10 @@
 
   <ItemGroup>
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/IntelligentPlant.Relativity/README.md
+++ b/src/IntelligentPlant.Relativity/README.md
@@ -1,0 +1,203 @@
+# IntelligentPlant.Relativity
+
+A C# library for converting absolute and relative timestamp strings into UTC `DateTime` instances, and duration strings into `TimeSpan` instances.
+
+
+# Getting Started
+
+The `IRelativityParser` interface defines a parser that can be used to convert relative timestamps and durations into absolute `DateTime` and `TimeSpan` instances. 
+
+Ain `IRelativityParser` parses timestamps and durations using a given `CultureInfo` and `TimeZoneInfo`. The `CultureInfo` controls how absolute timestamps and `TimeSpan` literals are parsed, as well as providing keywords that define the base times and time periods that can be used when defining relative timestamps or durations. The `TimeZoneInfo` controls the time zone that is used when converting relative timestamps to absolute timestamps.
+
+The static `RelativityParser` class provides quick access to several built-in parsers:
+
+* `RelativityParser.Invariant` - a parser that uses `CultureInfo.InvariantCulture` and the system's local time zone when converting relative timestamps to absolute timestamps.
+* `RelativityParser.InvariantUtc` - a parser that uses `CultureInfo.InvariantCulture` and UTC when converting relative timestamps to absolute timestamps.
+* `RelativityParser.Current` - the parser for the current asynchronous context. See [Asynchronous Control Flow](#asynchronous-control-flow) for more information.
+
+The `IRelativityParserFactory` interface defines a factory for creating custom `IRelativityParser` instances. The default implementation of `IRelativityParserFactory` is `RelativityParserFactory`. You can use the static `RelativityParserFactory.Default` property to obtain the default `IRelativityParserFactory` instance, or create your own instance of `RelativityParserFactory` directly.
+
+Parser configurations for additional cultures can be registered with the `IRelativityParserFactory`. To retrieve a parser instance for a specific culture, call the `GetParser` method on the factory:
+
+```csharp
+// Get a culture-specific parser that uses the system's local time zone.
+var enGBParser = factory.GetParser(CultureInfo.GetCultureInfo("en-GB"));
+```
+
+You can also specify a time zone for the parser to use when parsing relative timestamps:
+
+```csharp
+// Get a culture-specific parser that uses a specific time zone for relative 
+// timestamp conversion.
+var parser = factory.GetParser(CultureInfo.GetCultureInfo("en-GB"), 
+    TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
+```
+
+If a parser configuration is not registered for a requested culture (or any of its parent cultures), the returned parser will use the default (invariant) base time and time offset keywords when parsing relative timestamps and durations.
+
+
+# Parsing Timestamps
+
+Both absolute and relative timestamps can be parsed. Absolute timestamps are parsed according to the parser's `CultureInfo`:
+
+```csharp
+var date = parser.ConvertToUtcDateTime("2019-11-15T08:56:25.0901821Z");
+```
+
+Relative timestamps are expressed in the format `base_time [+/- offset]`, where the `base_time` matches one of the keywords defined in the parser's `BaseTimeSettings` property, and the `offset` is a number followed by one of the duration keywords defined in the parser's `TimeOffsetSettings` property (e.g. `3D` for 3 days when using the invariant culture parser). White space inside the expression is ignored and the parser uses case-insensitive matching against the `base_time` and `offset` values. 
+
+For invariant and English (`en`) culture parsers, the following `base_time` values can be used:
+
+| Keyword | Description | Notes |
+|---------|-------------| ----- |
+| `NOW` (or `*`) | Current time. |
+| `SECOND` | Start of the current second. |
+| `MINUTE` | Start of the current minute. |
+| `HOUR` | Start of the current hour. |
+| `DAY` | Start of the current day. |
+| `WEEK` | Start of the current week. | The `CultureInfo` for the parser is used to determine what the first day of the week is. |
+| `MONTH` | Start of the current month. |
+| `YEAR` | Start of the current year. |
+
+The following units can be used in relative timestamps with invariant and English-language parsers:
+
+| Keyword | Description | Fractional Quantities Allowed |
+|---------|-------------| ----------------------------- |
+| `MS` | Milliseconds | Yes |
+| `S` | Seconds | Yes |
+| `M` | Minutes | Yes |
+| `H` | Hours | Yes |
+| `D` | Days | Yes |
+| `W` | Weeks | Yes |
+| `MO` | Months | __No__ |
+| `Y` | Years | __No__ |
+
+Examples:
+
+| Example | Description |
+|---------|-------------|
+| `NOW + 15S` | Current time plus 15 seconds. |
+| `*-10y` | Current time minus 10 years. |
+| `day-0.5d` | Start of current day minus 0.5 days (i.e. 12 hours). |
+| `MONTH` | Start of the current month. |
+| `YEAR + 3MO` | Start of current year plus 3 calendar months. |
+
+> Note that the culture of the parser is also used when parsing offset quantities. For example, when using a parser with the `fi-FI` culture, the parser will expect a comma as a decimal separator when specifying a fractional quantity.
+
+Base time values are converted to absolute times relative to a given `DateTime` origin. If no origin is specified when parsing a timestamp, the current time for the parser's time zone is used:
+
+```csharp
+// No origin specified; current time for the parser's time zone is used as the origin.
+var date = parser.ConvertToUtcDateTime("DAY+6H");
+
+// Use 10 days ago in the parser's time zone as the origin.
+var date2 = parser.ConvertToUtcDateTime("DAY+6H", 
+    parser.TimeZone.GetCurrentTime().AddDays(-10));
+```
+
+# Parsing Durations
+
+The parser will parse literal time spans, as well as duration expressions. Literal time spans are parsed according to the parser's `CultureInfo`:
+
+```csharp
+var timeSpan = parser.ConvertToTimeSpan("3.19:03:27.775");
+```
+
+Duration expressions are expressed in the same way as an offset on a relative timestamp i.e. a quantity followed by one of the duration keywords defined in the `TimeOffsetSettings` property of the parser. The following units can be used in duration expressions with invariant and English-language parsers.
+
+| Keyword | Description | Fractional Quantities Allowed |
+|---------|-------------| ----------------------------- |
+| `MS` | Milliseconds | Yes |
+| `S` | Seconds | Yes |
+| `M` | Minutes | Yes |
+| `H` | Hours | Yes |
+| `D` | Days | Yes |
+| `W` | Weeks | Yes |
+
+Examples:
+
+| Example | Description |
+|---------|-------------|
+| `500ms` | 500 milliseconds. |
+| `15S` | 15 seconds. |
+| `0.5H` | 0.5 hours (i.e. 30 minutes). |
+| `1W` | 1 week. |
+
+> Note that the culture of the parser is also used when parsing duration expressions. For example, when using a parser with the `fi-FI` culture, the parser will expect a comma as a decimal separator when specifying a fractional quantity.
+
+
+# Registering Parsers
+
+A default set of well-known parser configurations are automatically registered with `RelativityParserFactory` when the factory is created.
+
+Additional parser configurations can also be passed to the `RelativityParserFactory` constructor; these configurations will override any matching default parser registrations. The invariant culture parsers cannot be overridden.
+
+To manually register a parser configuration for a given culture, call the `IRelativityParserFactory.TryRegisterParser` method:
+
+```csharp
+var fiFI = new RelativityParserConfiguration() {
+    CultureInfo = CultureInfo.GetCultureInfo("fi-FI"),
+    BaseTimeSettings = new RelativityBaseTimeSettings(
+        now: "NYT",
+        currentSecond: "SEKUNTI",
+        currentMinute: "MINUUTTI",
+        currentHour: "TUNTI",
+        currentDay: "PÄIVÄ",
+        currentWeek: "VIIKKO",
+        currentMonth: "KUUKAUSI",
+        currentYear: "VUOSI"
+    ),
+    TimeOffsetSettings = new RelativityTimeOffsetSettings(
+        milliseconds: "MS",
+        seconds: "S",
+        minutes: "M",
+        hours: "T",
+        days: "VK", // Vuorokausi i.e. a 24-hour period of time.
+        weeks: "VI",
+        months: "KK",
+        years: "V"
+    )
+};
+
+var success = factory.TryRegisterParser(fiFI);
+```
+
+By default, existing parser registrations are not overwritten. To force registration, specify a value for the `replaceExisting` parameter:
+
+```csharp
+var success = factory.TryRegisterParser(fiFI, replaceExisting: true);
+```
+
+
+# Asynchronous Control Flow
+
+You can use the static `RelativityParser.Current` property to get or set the parser for the current asynchronous context. This allows you to use the same parser anywhere within an asynchronous call stack without having to pass the parser as a parameter to each method. For example:
+
+```csharp
+private static async Task RunAsync(IRelativityParserFactory factory) {
+    var factory = new RelativityParserFactory();
+    var tasks = new[] { "Tokyo Standard Time", "Pacific Standard Time" }.Select(x => RunForTimeZoneAsync(factory, x));
+    await Task.WhenAll(tasks);
+}
+
+
+private static async Task RunForTimeZoneAsync(IRelativityParserFactory factory, string timeZone) {
+    RelativityParser.Current = factory.GetParser(CultureInfo.InvariantCulture, TimeZoneInfo.FindSystemTimeZoneById(timeZone));
+    await PrintStartOfMonthAsync();
+}
+
+
+private static async Task PrintStartOfMonthAsync() {
+    await Task.Delay(TimeSpan.FromSeconds(1));
+    var date = RelativityParser.Current.ConvertToUtcDateTime("MONTH");
+    Console.WriteLine($"{RelativityParser.Current.TimeZone.Id}: {date} UTC");
+}
+
+// Example output:
+// Tokyo Standard Time: 31/01/2024 15:00:00 UTC
+// Pacific Standard Time: 01/02/2024 08:00:00 UTC
+```
+
+If no value has been set for `RelativityParser.Current` for the current asynchronous context, `RelativityParser.InvariantUtc` will be returned.
+
+In [ASP.NET Core](https://www.nuget.org/packages/IntelligentPlant.Relativity.AspNetCore) or [OWIN](https://www.nuget.org/packages/IntelligentPlant.Relativity.Owin) web applications, you can use middleware to automatically set `RelativityParser.Current` for each request based on the culture and time zone information specified in the request.


### PR DESCRIPTION
This PR modifies the time zone providers in the ASP.NET Core and OWIN projects so that they use `ValueTask<T>` instead of `Task<T>` when resolving a `TimeZoneInfo`. The method implementation is synchronous in all of the built-in providers so it makes sense to use `ValueTask<T>` to remove the need to allocate a task.

The PR also adds package readme files for all projects and adds a v1 to v2 migration guide.