### PR TITLE
Convert TimeSpan to duration string

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -61,7 +61,7 @@ const string VersionFile = "./build/version.json";
 // 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-#load nuget:?package=Jaahas.Cake.Extensions&version=2.1.0
+#load nuget:?package=Jaahas.Cake.Extensions&version=2.3.0
 
 // Bootstrap build context and tasks.
 Bootstrap(DefaultSolutionFile, VersionFile);

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 2,
-  "Minor": 0,
+  "Minor": 1,
   "Patch": 0,
   "PreRelease": ""
 }

--- a/src/IntelligentPlant.Relativity/RelativityParserExtensions.cs
+++ b/src/IntelligentPlant.Relativity/RelativityParserExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace IntelligentPlant.Relativity {
 
@@ -137,6 +138,71 @@ namespace IntelligentPlant.Relativity {
                 throw new ArgumentNullException(nameof(parser));
             }
             return parser.TryConvertToTimeSpan(durationString, out _);
+        }
+
+
+        /// <summary>
+        /// Converts a <see cref="TimeSpan"/> to a Relativity duration string.
+        /// </summary>
+        /// <param name="parser">
+        ///   The parser.
+        /// </param>
+        /// <param name="timeSpan">
+        ///   The time span.
+        /// </param>
+        /// <param name="truncate">
+        ///   When <see langword="true"/>, the duration string will be rounded up to the nearest duration unit applicable to the <paramref name="timeSpan"/>.
+        /// </param>
+        /// <returns>
+        ///   The duration string.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="parser"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        /// 
+        /// <para>
+        ///   When <paramref name="truncate"/> is <see langword="true"/>, the duration string will 
+        ///   be rounded away from zero to the nearest duration unit applicable to the <paramref name="timeSpan"/>. 
+        ///   For example, if the <paramref name="timeSpan"/> is greater than one day and <paramref name="truncate"/> 
+        ///   is <see langword="true"/>, the duration string will be rounded up to the next day.
+        /// </para>
+        /// 
+        /// <para>
+        ///   Truncating the duration string is useful when you want to display a friendlier 
+        ///   duration at the expense of accuracy. The duration string will never be rounded 
+        ///   up or down further than to the nearest day.
+        /// </para>
+        /// 
+        /// </remarks>
+        public static string ConvertToDuration(this IRelativityParser parser, TimeSpan timeSpan, bool truncate = false) {
+            if (parser == null) {
+                throw new ArgumentNullException(nameof(parser));
+            }
+
+            if (Math.Abs(timeSpan.TotalDays) > 1) {
+                return string.Format(parser.CultureInfo, "{0}{1}", TruncateIfRequired(timeSpan.TotalDays), parser.TimeOffsetSettings.Days);
+            }
+
+            if (Math.Abs(timeSpan.TotalHours) > 1) {
+                return string.Format(parser.CultureInfo, "{0}{1}", TruncateIfRequired(timeSpan.TotalHours), parser.TimeOffsetSettings.Hours);
+            }
+
+            if (Math.Abs(timeSpan.TotalMinutes) > 1) {
+                return string.Format(parser.CultureInfo, "{0}{1}", TruncateIfRequired(timeSpan.TotalMinutes), parser.TimeOffsetSettings.Minutes);
+            }
+
+            if (Math.Abs(timeSpan.TotalSeconds) > 1) {
+                return string.Format(parser.CultureInfo, "{0}{1}", TruncateIfRequired(timeSpan.TotalSeconds), parser.TimeOffsetSettings.Seconds);
+            }
+
+            return string.Format(parser.CultureInfo, "{0}{1}", TruncateIfRequired(timeSpan.TotalMilliseconds), parser.TimeOffsetSettings.Milliseconds);
+
+            double TruncateIfRequired(double value) => truncate 
+                ? value > 0
+                    ? Math.Ceiling(value)
+                    : Math.Floor(value)
+                : value;
         }
 
     }

--- a/src/IntelligentPlant.Relativity/RelativityParserExtensions.cs
+++ b/src/IntelligentPlant.Relativity/RelativityParserExtensions.cs
@@ -180,19 +180,19 @@ namespace IntelligentPlant.Relativity {
                 throw new ArgumentNullException(nameof(parser));
             }
 
-            if (Math.Abs(timeSpan.TotalDays) > 1) {
+            if (Math.Abs(timeSpan.TotalDays) >= 1) {
                 return string.Format(parser.CultureInfo, "{0}{1}", TruncateIfRequired(timeSpan.TotalDays), parser.TimeOffsetSettings.Days);
             }
 
-            if (Math.Abs(timeSpan.TotalHours) > 1) {
+            if (Math.Abs(timeSpan.TotalHours) >= 1) {
                 return string.Format(parser.CultureInfo, "{0}{1}", TruncateIfRequired(timeSpan.TotalHours), parser.TimeOffsetSettings.Hours);
             }
 
-            if (Math.Abs(timeSpan.TotalMinutes) > 1) {
+            if (Math.Abs(timeSpan.TotalMinutes) >= 1) {
                 return string.Format(parser.CultureInfo, "{0}{1}", TruncateIfRequired(timeSpan.TotalMinutes), parser.TimeOffsetSettings.Minutes);
             }
 
-            if (Math.Abs(timeSpan.TotalSeconds) > 1) {
+            if (Math.Abs(timeSpan.TotalSeconds) >= 1) {
                 return string.Format(parser.CultureInfo, "{0}{1}", TruncateIfRequired(timeSpan.TotalSeconds), parser.TimeOffsetSettings.Seconds);
             }
 

--- a/test/IntelligentPlant.Relativity.Test/TimeSpanConversionTests.cs
+++ b/test/IntelligentPlant.Relativity.Test/TimeSpanConversionTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace IntelligentPlant.Relativity.Test {
+
+    [TestClass]
+    public class TimeSpanConversionTests {
+
+        [DataTestMethod]
+        [DataRow("1.18:00:00", false, "1.75D")]
+        [DataRow("1.18:00:00", true, "2D")]
+        [DataRow("18:30:00", false, "18.5H")]
+        [DataRow("18:30:00", true, "19H")]
+        [DataRow("00:15:45", false, "15.75M")]
+        [DataRow("00:15:45", true, "16M")]
+        [DataRow("00:00:01.250", false, "1.25S")]
+        [DataRow("00:00:01.250", true, "2S")]
+        [DataRow("00:00:00.2345678", false, "234.5678MS")]
+        [DataRow("00:00:00.2345768", true, "235MS")]
+        [DataRow("-1.18:00:00", false, "-1.75D")]
+        [DataRow("-1.18:00:00", true, "-2D")]
+        [DataRow("-18:30:00", false, "-18.5H")]
+        [DataRow("-18:30:00", true, "-19H")]
+        [DataRow("-00:15:45", false, "-15.75M")]
+        [DataRow("-00:15:45", true, "-16M")]
+        [DataRow("-00:00:01.250", false, "-1.25S")]
+        [DataRow("-00:00:01.250", true, "-2S")]
+        [DataRow("-00:00:00.2345678", false, "-234.5678MS")]
+        [DataRow("-00:00:00.2345768", true, "-235MS")]
+        public void ShouldConvertToDuration(string timeSpanLiteral, bool truncateDuration, string expectedDuration) { 
+            var timeSpan = TimeSpan.Parse(timeSpanLiteral);
+            var duration = RelativityParser.InvariantUtc.ConvertToDuration(timeSpan, truncateDuration);
+            Assert.AreEqual(expectedDuration, duration);
+        }
+
+
+    }
+
+}


### PR DESCRIPTION
This PR adds a new `RelativityParserExtensions.ConvertToDuration` extension method that converts a `TimeSpan` to an equivalent duration string (e.g. `1.18:00:00` => `"1.75D"`).

The duration string can also optionally be rounded to the next duration unit if a more user-friendly (but less accurate) duration string is preferred (e.g. `1.18:00:00` => `"2D"`).