### PR TITLE
Improved TimeSpan to duration string conversion

### DIFF
--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 2,
-  "Minor": 1,
+  "Minor": 2,
   "Patch": 0,
   "PreRelease": ""
 }

--- a/test/IntelligentPlant.Relativity.Test/TimeSpanConversionTests.cs
+++ b/test/IntelligentPlant.Relativity.Test/TimeSpanConversionTests.cs
@@ -8,29 +8,47 @@ namespace IntelligentPlant.Relativity.Test {
     public class TimeSpanConversionTests {
 
         [DataTestMethod]
-        [DataRow("1.18:00:00", false, "1.75D")]
-        [DataRow("1.18:00:00", true, "2D")]
-        [DataRow("18:30:00", false, "18.5H")]
-        [DataRow("18:30:00", true, "19H")]
-        [DataRow("00:15:45", false, "15.75M")]
-        [DataRow("00:15:45", true, "16M")]
-        [DataRow("00:00:01.250", false, "1.25S")]
-        [DataRow("00:00:01.250", true, "2S")]
-        [DataRow("00:00:00.2345678", false, "234.5678MS")]
-        [DataRow("00:00:00.2345768", true, "235MS")]
-        [DataRow("-1.18:00:00", false, "-1.75D")]
-        [DataRow("-1.18:00:00", true, "-2D")]
-        [DataRow("-18:30:00", false, "-18.5H")]
-        [DataRow("-18:30:00", true, "-19H")]
-        [DataRow("-00:15:45", false, "-15.75M")]
-        [DataRow("-00:15:45", true, "-16M")]
-        [DataRow("-00:00:01.250", false, "-1.25S")]
-        [DataRow("-00:00:01.250", true, "-2S")]
-        [DataRow("-00:00:00.2345678", false, "-234.5678MS")]
-        [DataRow("-00:00:00.2345768", true, "-235MS")]
-        public void ShouldConvertToDuration(string timeSpanLiteral, bool truncateDuration, string expectedDuration) { 
+        [DataRow("1.18:00:00", 2, "1.75D")]
+        [DataRow("1.18:00:00", 1, "1.8D")]
+        [DataRow("1.18:00:00", 0, "2D")]
+        [DataRow("18:30:00", 1, "18.5H")]
+        [DataRow("18:30:00", 0, "19H")]
+        [DataRow("00:15:45", 2, "15.75M")]
+        [DataRow("00:15:45", 1, "15.8M")]
+        [DataRow("00:15:45", 0, "16M")]
+        [DataRow("00:00:01.250", 2, "1.25S")]
+        [DataRow("00:00:01.250", 1, "1.3S")]
+        [DataRow("00:00:01.250", 0, "2S")]
+        [DataRow("00:00:00.2345678", -1, "234.5678MS")]
+        [DataRow("00:00:00.2345768", 0, "235MS")]
+        [DataRow("-1.18:00:00", 2, "-1.75D")]
+        [DataRow("-1.18:00:00", 1, "-1.8D")]
+        [DataRow("-1.18:00:00", 0, "-2D")]
+        [DataRow("-18:30:00", 1, "-18.5H")]
+        [DataRow("-18:30:00", 0, "-19H")]
+        [DataRow("-00:15:45", 2, "-15.75M")]
+        [DataRow("-00:15:45", 1, "-15.8M")]
+        [DataRow("-00:15:45", 0, "-16M")]
+        [DataRow("-00:00:01.250", 2, "-1.25S")]
+        [DataRow("-00:00:01.250", 1, "-1.3S")]
+        [DataRow("-00:00:01.250", 0, "-2S")]
+        [DataRow("-00:00:00.2345678", -1, "-234.5678MS")]
+        [DataRow("-00:00:00.2345768", 0, "-235MS")]
+        public void ShouldConvertToDurationWithSpecifiedPrecision(string timeSpanLiteral, int decimalPlaces, string expectedDuration) {
             var timeSpan = TimeSpan.Parse(timeSpanLiteral);
-            var duration = RelativityParser.InvariantUtc.ConvertToDuration(timeSpan, truncateDuration);
+            var duration = RelativityParser.InvariantUtc.ConvertToDuration(timeSpan, decimalPlaces: decimalPlaces);
+            Assert.AreEqual(expectedDuration, duration);
+        }
+
+
+        [DataTestMethod]
+        [DataRow("1.18:00:00", "H", "42H")]
+        [DataRow("01:30:00", "M", "90M")]
+        [DataRow("00:05:30", "S", "330S")]
+        [DataRow("00:00:01.500", "MS", "1500MS")]
+        public void ShouldConvertToDurationWithSpecifiedUnits(string timeSpanLiteral, string unit, string expectedDuration) {
+            var timeSpan = TimeSpan.Parse(timeSpanLiteral);
+            var duration = RelativityParser.InvariantUtc.ConvertToDuration(timeSpan, unit: unit);
             Assert.AreEqual(expectedDuration, duration);
         }
 


### PR DESCRIPTION
This PR modifies the signature of `RelativityParserExtensions.ConvertToDuration` so that instead of a simple truncate yes/no option, it allows the number of decimal places to be specified and optionally allows the unit to use for the duration to be provided instead of being inferred from the magnitude of the TimeSpan.

This is technically a breaking change but the PR only bumps the minor version of the library on the basis that the v2.1 release is only just out the door.