### PR TITLE
Composite unit durations

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ The following units can be used in relative timestamps with invariant and Englis
 | `MO` | Months | __No__ |
 | `Y` | Years | __No__ |
 
+Combinations of units can be used to specify more complex offsets.
+
 Examples:
 
 | Example | Description |
@@ -81,6 +83,8 @@ Examples:
 | `day-0.5d` | Start of current day minus 0.5 days (i.e. 12 hours). |
 | `MONTH` | Start of the current month. |
 | `YEAR + 3MO` | Start of current year plus 3 calendar months. |
+| `WEEK - 12H 30M 57S` | Start of the current week minus 12 hours 30 minutes 57 seconds. |
+| `MONTH + 8h30m` | Start of the current month plus 8 hours 30 minutes. |
 
 > Note that the culture of the parser is also used when parsing offset quantities. For example, when using a parser with the `fi-FI` culture, the parser will expect a comma as a decimal separator when specifying a fractional quantity.
 
@@ -113,6 +117,8 @@ Duration expressions are expressed in the same way as an offset on a relative ti
 | `D` | Days | Yes |
 | `W` | Weeks | Yes |
 
+Combinations of units can be used to specify more complex durations.
+
 Examples:
 
 | Example | Description |
@@ -121,6 +127,8 @@ Examples:
 | `15S` | 15 seconds. |
 | `0.5H` | 0.5 hours (i.e. 30 minutes). |
 | `1W` | 1 week. |
+| `2D 6H 30M` | 2 days 6 hours 30 minutes. |
+| `1w3d12h` | 1 week 3 days 12 hours. |
 
 > Note that the culture of the parser is also used when parsing duration expressions. For example, when using a parser with the `fi-FI` culture, the parser will expect a comma as a decimal separator when specifying a fractional quantity.
 

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
-  "Major": 2,
-  "Minor": 2,
+  "Major": 3,
+  "Minor": 0,
   "Patch": 0,
   "PreRelease": ""
 }

--- a/src/IntelligentPlant.Relativity/DurationBuilder.cs
+++ b/src/IntelligentPlant.Relativity/DurationBuilder.cs
@@ -1,0 +1,308 @@
+﻿using System;
+using System.Text;
+
+namespace IntelligentPlant.Relativity {
+
+    /// <summary>
+    /// A builder for creating duration strings.
+    /// </summary>
+    public sealed class DurationBuilder {
+
+        /// <summary>
+        /// The parser to use when building the duration string.
+        /// </summary>
+        private readonly IRelativityParser _parser;
+
+        private double? _milliseconds;
+
+        private double? _seconds;
+
+        private double? _minutes;
+
+        private double? _hours;
+
+        private double? _days;
+
+        private double? _weeks;
+
+
+        /// <summary>
+        /// Creates a new <see cref="DurationBuilder"/> instance.
+        /// </summary>
+        /// <param name="parser">
+        ///   The parser to use when building the duration string. Specify <see langword="null"/> 
+        ///   to use <see cref="RelativityParser.InvariantUtc"/>.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        ///   The parser does not define symbols for any duration components.
+        /// </exception>
+        public DurationBuilder(IRelativityParser? parser = null) {
+            _parser = parser ?? RelativityParser.InvariantUtc;
+            if (_parser.TimeOffsetSettings.Weeks == null &&
+                _parser.TimeOffsetSettings.Days == null &&
+                _parser.TimeOffsetSettings.Hours == null &&
+                _parser.TimeOffsetSettings.Minutes == null &&
+                _parser.TimeOffsetSettings.Seconds == null &&
+                _parser.TimeOffsetSettings.Milliseconds == null) {
+                throw new ArgumentException("No duration components are enabled.", nameof(parser));
+            }
+        }
+
+
+        private void ThrowOnUndefinedSymbol(string? symbol) {
+            if (symbol == null) {
+                throw new InvalidOperationException("Parser does not define a symbol for this duration unit.");
+            }
+        }
+
+
+        private void ThrowOnInvalidValue(double value) {
+            if (value < 0) {
+                throw new ArgumentOutOfRangeException(nameof(value), "Duration values cannot be less than zero.");
+            }
+        }
+
+
+        /// <summary>
+        /// Sets the value of a duration component.
+        /// </summary>
+        /// <param name="unit">
+        ///   The duration component to set.
+        /// </param>
+        /// <param name="value">
+        ///   The duration value.
+        /// </param>
+        /// <returns>
+        ///   The builder.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="unit"/> is <see cref="DurationUnitKind.Unspecified"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="value"/> is less than zero.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   The <see cref="IRelativityParser"/> for the builder does not define a symbol for the 
+        ///   specified <paramref name="unit"/>.
+        /// </exception>
+        public DurationBuilder SetComponent(DurationUnitKind unit, double value) {
+            ThrowOnInvalidValue(value);
+
+            switch (unit) {
+                case DurationUnitKind.Weeks:
+                    ThrowOnUndefinedSymbol(_parser.TimeOffsetSettings.Weeks);
+                    _weeks = value;
+                    break;
+                case DurationUnitKind.Days:
+                    ThrowOnUndefinedSymbol(_parser.TimeOffsetSettings.Days);
+                    _days = value;
+                    break;
+                case DurationUnitKind.Hours:
+                    ThrowOnUndefinedSymbol(_parser.TimeOffsetSettings.Hours);
+                    _hours = value;
+                    break;
+                case DurationUnitKind.Minutes:
+                    ThrowOnUndefinedSymbol(_parser.TimeOffsetSettings.Minutes);
+                    _minutes = value;
+                    break;
+                case DurationUnitKind.Seconds:
+                    ThrowOnUndefinedSymbol(_parser.TimeOffsetSettings.Seconds);
+                    _seconds = value;
+                    break;
+                case DurationUnitKind.Milliseconds:
+                    ThrowOnUndefinedSymbol(_parser.TimeOffsetSettings.Milliseconds);
+                    _milliseconds = value;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(unit));
+            }
+
+            return this;
+        }
+
+
+        /// <summary>
+        /// Sets the number of weeks in the duration.
+        /// </summary>
+        /// <param name="value">
+        ///   The number of weeks.
+        /// </param>
+        /// <returns>
+        ///   The builder.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="value"/> is less than zero.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   The <see cref="IRelativityParser"/> for the builder does not define a symbol for weeks.
+        /// </exception>
+        public DurationBuilder Weeks(double value) => SetComponent(DurationUnitKind.Weeks, value);
+
+
+        /// <summary>
+        /// Sets the number of days in the duration.
+        /// </summary>
+        /// <param name="value">
+        ///   The number of days.
+        /// </param>
+        /// <returns>
+        ///   The builder.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="value"/> is less than zero.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   The <see cref="IRelativityParser"/> for the builder does not define a symbol for days.
+        /// </exception>
+        public DurationBuilder Days(double value) => SetComponent(DurationUnitKind.Days, value);
+
+
+        /// <summary>
+        /// Sets the number of hours in the duration.
+        /// </summary>
+        /// <param name="value">
+        ///   The number of hours.
+        /// </param>
+        /// <returns>
+        ///   The builder.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="value"/> is less than zero.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   The <see cref="IRelativityParser"/> for the builder does not define a symbol for hours.
+        /// </exception>
+        public DurationBuilder Hours(double value) => SetComponent(DurationUnitKind.Hours, value);
+
+
+        /// <summary>
+        /// Sets the number of minutes in the duration.
+        /// </summary>
+        /// <param name="value">
+        ///   The number of minutes.
+        /// </param>
+        /// <returns>
+        ///   The builder.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="value"/> is less than zero.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   The <see cref="IRelativityParser"/> for the builder does not define a symbol for minutes.
+        /// </exception>
+        public DurationBuilder Minutes(double value) => SetComponent(DurationUnitKind.Minutes, value);
+
+
+        /// <summary>
+        /// Sets the number of seconds in the duration.
+        /// </summary>
+        /// <param name="value">
+        ///   The number of seconds.
+        /// </param>
+        /// <returns>
+        ///   The builder.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="value"/> is less than zero.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   The <see cref="IRelativityParser"/> for the builder does not define a symbol for seconds.
+        /// </exception>
+        public DurationBuilder Seconds(double value) => SetComponent(DurationUnitKind.Seconds, value);
+
+
+        /// <summary>
+        /// Sets the number of milliseconds in the duration.
+        /// </summary>
+        /// <param name="value">
+        ///   The number of milliseconds.
+        /// </param>
+        /// <returns>
+        ///   The builder.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="value"/> is less than zero.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   The <see cref="IRelativityParser"/> for the builder does not define a symbol for milliseconds.
+        /// </exception>
+        public DurationBuilder Milliseconds(double value) => SetComponent(DurationUnitKind.Milliseconds, value);
+
+
+        /// <summary>
+        /// Builds the duration string.
+        /// </summary>
+        /// <returns>
+        ///   The duration string.
+        /// </returns>
+        public string Build() {
+            if (!_milliseconds.HasValue && !_seconds.HasValue && !_minutes.HasValue && !_hours.HasValue && !_days.HasValue && !_weeks.HasValue) {
+                return _parser.CreateEmptyDurationString();
+            }
+
+            var sb = new StringBuilder();
+            var appendSeparator = false;
+
+            if (_weeks > 0) {
+                appendSeparator = true;
+                sb.AppendFormat(_parser.CultureInfo, "{0}{1}", _weeks, _parser.GetSymbol(DurationUnitKind.Weeks));
+            }
+
+            if (_days > 0) {
+                if (appendSeparator) {
+                    sb.Append(" ");
+                }
+                else {
+                    appendSeparator = true;
+                }
+                sb.AppendFormat(_parser.CultureInfo, "{0}{1}", _days, _parser.GetSymbol(DurationUnitKind.Days));
+            }
+
+            if (_hours > 0) {
+                if (appendSeparator) {
+                    sb.Append(" ");
+                }
+                else {
+                    appendSeparator = true;
+                }
+                sb.AppendFormat(_parser.CultureInfo, "{0}{1}", _hours, _parser.GetSymbol(DurationUnitKind.Hours));
+            }
+
+            if (_minutes > 0) {
+                if (appendSeparator) {
+                    sb.Append(" ");
+                }
+                else {
+                    appendSeparator = true;
+                }
+                sb.AppendFormat(_parser.CultureInfo, "{0}{1}", _minutes, _parser.GetSymbol(DurationUnitKind.Minutes));
+            }
+
+            if (_seconds > 0) {
+                if (appendSeparator) {
+                    sb.Append(" ");
+                }
+                else {
+                    appendSeparator = true;
+                }
+                sb.AppendFormat(_parser.CultureInfo, "{0}{1}", _seconds, _parser.GetSymbol(DurationUnitKind.Seconds));
+            }
+
+            if (_milliseconds > 0) {
+                if (appendSeparator) {
+                    sb.Append(" ");
+                }
+                else {
+                    appendSeparator = true;
+                }
+                sb.AppendFormat(_parser.CultureInfo, "{0}{1}", _milliseconds, _parser.GetSymbol(DurationUnitKind.Milliseconds));
+            }
+
+            return sb.Length == 0
+                ? _parser.CreateEmptyDurationString()
+                : sb.ToString();
+
+        }
+
+    }
+}

--- a/src/IntelligentPlant.Relativity/DurationUnitKind.cs
+++ b/src/IntelligentPlant.Relativity/DurationUnitKind.cs
@@ -1,0 +1,45 @@
+﻿namespace IntelligentPlant.Relativity {
+
+    /// <summary>
+    /// Describes the unit of a duration.
+    /// </summary>
+    public enum DurationUnitKind {
+
+        /// <summary>
+        /// Unspecified.
+        /// </summary>
+        Unspecified,
+
+        /// <summary>
+        /// Milliseconds.
+        /// </summary>
+        Milliseconds,
+
+        /// <summary>
+        /// Seconds.
+        /// </summary>
+        Seconds,
+
+        /// <summary>
+        /// Minutes.
+        /// </summary>
+        Minutes,
+
+        /// <summary>
+        /// Hours.
+        /// </summary>
+        Hours,
+
+        /// <summary>
+        /// Days.
+        /// </summary>
+        Days,
+
+        /// <summary>
+        /// Weeks.
+        /// </summary>
+        Weeks
+
+    }
+
+}

--- a/src/IntelligentPlant.Relativity/Internal/ParserBase.cs
+++ b/src/IntelligentPlant.Relativity/Internal/ParserBase.cs
@@ -256,14 +256,9 @@ namespace IntelligentPlant.Relativity.Internal {
             var match = RelativeDateRegex.Match(dateString);
             if (match.Success) {
                 var absoluteBaseDate = ConvertRelativeBaseTimeToAbsolute(match.Groups["base"].Value, currentTimeParserTz, CultureInfo, BaseTimeSettings);
-                var unit = match.Groups["unit"].Value;
-                var quantityRaw = match.Groups["count"].Value;
-                var quantity = string.IsNullOrWhiteSpace(quantityRaw) 
-                    ? 0 
-                    : double.Parse(match.Groups["count"].Value, CultureInfo);
                 var add = match.Groups["operator"].Success && "+".Equals(match.Groups["operator"].Value, StringComparison.Ordinal);
 
-                dateTime = ApplyOffset(absoluteBaseDate, unit, quantity, add, TimeOffsetSettings);
+                dateTime = ApplyOffset(absoluteBaseDate, match, add, TimeOffsetSettings);
                 return true;
             }
 
@@ -337,16 +332,13 @@ namespace IntelligentPlant.Relativity.Internal {
 
 
         /// <summary>
-        /// Adjusts a <see cref="DateTime"/> based on the specified time unit and quantity.
+        /// Adjusts a <see cref="DateTime"/> based on the offset defined by the specified regex match.
         /// </summary>
         /// <param name="baseDate">
         ///   The <see cref="DateTime"/> to adjust.
         /// </param>
-        /// <param name="unit">
-        ///   The time unit.
-        /// </param>
-        /// <param name="quantity">
-        ///   The time unit quantity.
+        /// <param name="match">
+        ///   The regex match that defines the offset.
         /// </param>
         /// <param name="add">
         ///   Indicates if the time span should be added to or removed from the <paramref name="baseDate"/>.
@@ -357,55 +349,98 @@ namespace IntelligentPlant.Relativity.Internal {
         /// <returns>
         ///   The adjusted <see cref="DateTime"/>.
         /// </returns>
-        private static DateTime ApplyOffset(DateTime baseDate, string unit, double quantity, bool add, RelativityTimeOffsetSettings timeOffsetSettings) {
-            if (quantity == 0) {
-                return baseDate;
+        private DateTime ApplyOffset(DateTime baseDate, Match match, bool add, RelativityTimeOffsetSettings timeOffsetSettings) {
+            var result = baseDate;
+            
+            var years = match.Groups["years"]?.Value;
+            if (!string.IsNullOrWhiteSpace(years)) {
+                var magnitude = int.Parse(years, NumberStyles.Integer, CultureInfo);
+                if (add) {
+                    result = result.AddYears(magnitude);
+                }
+                else {
+                    result = result.AddYears(-1 * magnitude);
+                }
             }
 
-            if (string.Equals(unit, timeOffsetSettings.Years, StringComparison.OrdinalIgnoreCase)) {
-                var wholeQuantity = Convert.ToInt32(quantity);
-                return add
-                    ? baseDate.AddYears(wholeQuantity)
-                    : baseDate.AddYears(-1 * wholeQuantity);
-            }
-            if (string.Equals(unit, timeOffsetSettings.Months, StringComparison.OrdinalIgnoreCase)) {
-                var wholeQuantity = Convert.ToInt32(quantity);
-                return add
-                    ? baseDate.AddMonths(wholeQuantity)
-                    : baseDate.AddMonths(-1 * wholeQuantity);
-            }
-            if (string.Equals(unit, timeOffsetSettings.Weeks, StringComparison.OrdinalIgnoreCase)) {
-                return add
-                    ? baseDate.AddDays(7 * quantity)
-                    : baseDate.AddDays(-7 * quantity);
-            }
-            if (string.Equals(unit, timeOffsetSettings.Days, StringComparison.OrdinalIgnoreCase)) {
-                return add
-                    ? baseDate.AddDays(quantity)
-                    : baseDate.AddDays(-1 * quantity);
-            }
-            if (string.Equals(unit, timeOffsetSettings.Hours, StringComparison.OrdinalIgnoreCase)) {
-                return add
-                    ? baseDate.AddHours(quantity)
-                    : baseDate.AddHours(-1 * quantity);
-            }
-            if (string.Equals(unit, timeOffsetSettings.Minutes, StringComparison.OrdinalIgnoreCase)) {
-                return add
-                    ? baseDate.AddMinutes(quantity)
-                    : baseDate.AddMinutes(-1 * quantity);
-            }
-            if (string.Equals(unit, timeOffsetSettings.Seconds, StringComparison.OrdinalIgnoreCase)) {
-                return add
-                    ? baseDate.AddSeconds(quantity)
-                    : baseDate.AddSeconds(-1 * quantity);
-            }
-            if (string.Equals(unit, timeOffsetSettings.Milliseconds, StringComparison.OrdinalIgnoreCase)) {
-                return add
-                    ? baseDate.AddMilliseconds(quantity)
-                    : baseDate.AddMilliseconds(-1 * quantity);
+            var months = match.Groups["months"]?.Value;
+            if (!string.IsNullOrWhiteSpace(months)) {
+                var magnitude = int.Parse(months, NumberStyles.Integer, CultureInfo);
+                if (add) {
+                    result = result.AddMonths(magnitude);
+                }
+                else {
+                    result = result.AddMonths(-1 * magnitude);
+                }
             }
 
-            return baseDate;
+            var weeks = match.Groups["weeks"]?.Value;
+            if (!string.IsNullOrWhiteSpace(weeks)) {
+                var magnitude = double.Parse(weeks, CultureInfo);
+                if (add) {
+                    result = result.AddDays(7 * magnitude);
+                }
+                else {
+                    result = result.AddDays(-7 * magnitude);
+                }
+            }
+
+            var days = match.Groups["days"]?.Value;
+            if (!string.IsNullOrWhiteSpace(days)) {
+                var magnitude = double.Parse(days, CultureInfo);
+                if (add) {
+                    result = result.AddDays(magnitude);
+                }
+                else {
+                    result = result.AddDays(-1 * magnitude);
+                }
+            }
+
+            var hours = match.Groups["hours"]?.Value;
+            if (!string.IsNullOrWhiteSpace(hours)) {
+                var magnitude = double.Parse(hours, CultureInfo);
+                if (add) {
+                    result = result.AddHours(magnitude);
+                }
+                else {
+                    result = result.AddHours(-1 * magnitude);
+                }
+            }
+
+            var minutes = match.Groups["minutes"]?.Value;
+            if (!string.IsNullOrWhiteSpace(minutes)) {
+                var magnitude = double.Parse(minutes, CultureInfo);
+                if (add) {
+                    result = result.AddMinutes(magnitude);
+                }
+                else {
+                    result = result.AddMinutes(-1 * magnitude);
+                }
+            }
+
+            var seconds = match.Groups["seconds"]?.Value;
+            if (!string.IsNullOrWhiteSpace(seconds)) {
+                var magnitude = double.Parse(seconds, CultureInfo);
+                if (add) {
+                    result = result.AddSeconds(magnitude);
+                }
+                else {
+                    result = result.AddSeconds(-1 * magnitude);
+                }
+            }
+
+            var milliseconds = match.Groups["milliseconds"]?.Value;
+            if (!string.IsNullOrWhiteSpace(milliseconds)) {
+                var magnitude = double.Parse(milliseconds, CultureInfo);
+                if (add) {
+                    result = result.AddMilliseconds(magnitude);
+                }
+                else {
+                    result = result.AddMilliseconds(-1 * magnitude);
+                }
+            }
+
+            return result;
         }
 
 
@@ -429,29 +464,42 @@ namespace IntelligentPlant.Relativity.Internal {
                 return false;
             }
 
-            var unit = match.Groups["unit"].Value;
-            var quantity = Convert.ToDouble(match.Groups["count"].Value, CultureInfo);
+            timeSpan = TimeSpan.Zero;
 
-            if (string.Equals(unit, TimeOffsetSettings.Weeks, StringComparison.OrdinalIgnoreCase)) {
-                timeSpan = TimeSpan.FromTicks((long) (TimeSpan.TicksPerDay * 7 * quantity));
+            var weeks = match.Groups["weeks"]?.Value;
+            if (!string.IsNullOrWhiteSpace(weeks)) {
+                var magnitude = double.Parse(weeks, CultureInfo);
+                timeSpan = timeSpan.Add(TimeSpan.FromTicks((long) (TimeSpan.TicksPerDay * 7 * magnitude)));
             }
-            else if (string.Equals(unit, TimeOffsetSettings.Days, StringComparison.OrdinalIgnoreCase)) {
-                timeSpan = TimeSpan.FromTicks((long) (TimeSpan.TicksPerDay * quantity));
+
+            var days = match.Groups["days"]?.Value;
+            if (!string.IsNullOrWhiteSpace(days)) {
+                var magnitude = double.Parse(days, CultureInfo);
+                timeSpan = timeSpan.Add(TimeSpan.FromTicks((long) (TimeSpan.TicksPerDay * magnitude)));
             }
-            else if (string.Equals(unit, TimeOffsetSettings.Hours, StringComparison.OrdinalIgnoreCase)) {
-                timeSpan = TimeSpan.FromTicks((long) (TimeSpan.TicksPerHour * quantity));
+
+            var hours = match.Groups["hours"]?.Value;
+            if (!string.IsNullOrWhiteSpace(hours)) {
+                var magnitude = double.Parse(hours, CultureInfo);
+                timeSpan = timeSpan.Add(TimeSpan.FromTicks((long) (TimeSpan.TicksPerHour * magnitude)));
             }
-            else if (string.Equals(unit, TimeOffsetSettings.Minutes, StringComparison.OrdinalIgnoreCase)) {
-                timeSpan = TimeSpan.FromTicks((long) (TimeSpan.TicksPerMinute * quantity));
+
+            var minutes = match.Groups["minutes"]?.Value;
+            if (!string.IsNullOrWhiteSpace(minutes)) {
+                var magnitude = double.Parse(minutes, CultureInfo);
+                timeSpan = timeSpan.Add(TimeSpan.FromTicks((long) (TimeSpan.TicksPerMinute * magnitude)));
             }
-            else if (string.Equals(unit, TimeOffsetSettings.Seconds, StringComparison.OrdinalIgnoreCase)) {
-                timeSpan = TimeSpan.FromTicks((long) (TimeSpan.TicksPerSecond * quantity));
+
+            var seconds = match.Groups["seconds"]?.Value;
+            if (!string.IsNullOrWhiteSpace(seconds)) {
+                var magnitude = double.Parse(seconds, CultureInfo);
+                timeSpan = timeSpan.Add(TimeSpan.FromTicks((long) (TimeSpan.TicksPerSecond * magnitude)));
             }
-            else if (string.Equals(unit, TimeOffsetSettings.Milliseconds, StringComparison.OrdinalIgnoreCase)) {
-                timeSpan = TimeSpan.FromTicks((long) (TimeSpan.TicksPerMillisecond * quantity));
-            }
-            else {
-                timeSpan = default;
+
+            var milliseconds = match.Groups["milliseconds"]?.Value;
+            if (!string.IsNullOrWhiteSpace(milliseconds)) {
+                var magnitude = double.Parse(milliseconds, CultureInfo);
+                timeSpan = timeSpan.Add(TimeSpan.FromTicks((long) (TimeSpan.TicksPerMillisecond * magnitude)));
             }
 
             return true;

--- a/src/IntelligentPlant.Relativity/README.md
+++ b/src/IntelligentPlant.Relativity/README.md
@@ -72,6 +72,8 @@ The following units can be used in relative timestamps with invariant and Englis
 | `MO` | Months | __No__ |
 | `Y` | Years | __No__ |
 
+Combinations of units can be used to specify more complex offsets.
+
 Examples:
 
 | Example | Description |
@@ -81,6 +83,8 @@ Examples:
 | `day-0.5d` | Start of current day minus 0.5 days (i.e. 12 hours). |
 | `MONTH` | Start of the current month. |
 | `YEAR + 3MO` | Start of current year plus 3 calendar months. |
+| `WEEK - 12H 30M 57S` | Start of the current week minus 12 hours 30 minutes 57 seconds. |
+| `MONTH + 8h30m` | Start of the current month plus 8 hours 30 minutes. |
 
 > Note that the culture of the parser is also used when parsing offset quantities. For example, when using a parser with the `fi-FI` culture, the parser will expect a comma as a decimal separator when specifying a fractional quantity.
 
@@ -114,6 +118,8 @@ Duration expressions are expressed in the same way as an offset on a relative ti
 | `D` | Days | Yes |
 | `W` | Weeks | Yes |
 
+Combinations of units can be used to specify more complex durations.
+
 Examples:
 
 | Example | Description |
@@ -122,6 +128,8 @@ Examples:
 | `15S` | 15 seconds. |
 | `0.5H` | 0.5 hours (i.e. 30 minutes). |
 | `1W` | 1 week. |
+| `2D 6H 30M` | 2 days 6 hours 30 minutes. |
+| `1w3d12h` | 1 week 3 days 12 hours. |
 
 > Note that the culture of the parser is also used when parsing duration expressions. For example, when using a parser with the `fi-FI` culture, the parser will expect a comma as a decimal separator when specifying a fractional quantity.
 

--- a/src/IntelligentPlant.Relativity/RelativeTimeOffsetUnitKind.cs
+++ b/src/IntelligentPlant.Relativity/RelativeTimeOffsetUnitKind.cs
@@ -1,0 +1,55 @@
+﻿namespace IntelligentPlant.Relativity {
+
+    /// <summary>
+    /// Describes the unit of a duration.
+    /// </summary>
+    public enum RelativeTimeOffsetUnitKind {
+
+        /// <summary>
+        /// Unspecified.
+        /// </summary>
+        Unspecified,
+
+        /// <summary>
+        /// Milliseconds.
+        /// </summary>
+        Milliseconds,
+
+        /// <summary>
+        /// Seconds.
+        /// </summary>
+        Seconds,
+
+        /// <summary>
+        /// Minutes.
+        /// </summary>
+        Minutes,
+
+        /// <summary>
+        /// Hours.
+        /// </summary>
+        Hours,
+
+        /// <summary>
+        /// Days.
+        /// </summary>
+        Days,
+
+        /// <summary>
+        /// Weeks.
+        /// </summary>
+        Weeks,
+
+        /// <summary>
+        /// Months.
+        /// </summary>
+        Months,
+
+        /// <summary>
+        /// Years.
+        /// </summary>
+        Years
+
+    }
+
+}

--- a/src/IntelligentPlant.Relativity/RelativeTimeOriginKind.cs
+++ b/src/IntelligentPlant.Relativity/RelativeTimeOriginKind.cs
@@ -1,0 +1,55 @@
+﻿namespace IntelligentPlant.Relativity {
+
+    /// <summary>
+    /// Describes the kind of a relative time origin.
+    /// </summary>
+    public enum RelativeTimeOriginKind {
+
+        /// <summary>
+        /// Unspecified.
+        /// </summary>
+        Unspecified,
+
+        /// <summary>
+        /// Current time.
+        /// </summary>
+        Now,
+
+        /// <summary>
+        /// The start of the current second.
+        /// </summary>
+        CurrentSecond,
+
+        /// <summary>
+        /// The start of the current minute.
+        /// </summary>
+        CurrentMinute,
+
+        /// <summary>
+        /// The start of the current hour.
+        /// </summary>
+        CurrentHour,
+
+        /// <summary>
+        /// The start of the current day.
+        /// </summary>
+        CurrentDay,
+
+        /// <summary>
+        /// The start of the current week.
+        /// </summary>
+        CurrentWeek,
+
+        /// <summary>
+        /// The start of the current month.
+        /// </summary>
+        CurrentMonth,
+
+        /// <summary>
+        /// The start of the current year.
+        /// </summary>
+        CurrentYear
+
+    }
+
+}

--- a/src/IntelligentPlant.Relativity/RelativityParserExtensions.cs
+++ b/src/IntelligentPlant.Relativity/RelativityParserExtensions.cs
@@ -1,5 +1,9 @@
 ﻿using System;
 using System.Globalization;
+using System.Runtime;
+using System.Text;
+
+using IntelligentPlant.Relativity.Internal;
 
 namespace IntelligentPlant.Relativity {
 
@@ -142,6 +146,101 @@ namespace IntelligentPlant.Relativity {
 
 
         /// <summary>
+        /// Converts the specified <see cref="TimeSpan"/> to a Relativity duration string.
+        /// </summary>
+        /// <param name="parser">
+        ///   The parser.
+        /// </param>
+        /// <param name="timeSpan">
+        ///   The time span.
+        /// </param>
+        /// <returns>
+        ///   The duration string.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="parser"/> is <see langword="null"/>.
+        /// </exception>
+        public static string ConvertToDuration(this IRelativityParser parser, TimeSpan timeSpan) {
+            if (parser == null) {
+                throw new ArgumentNullException(nameof(parser));
+            }
+
+            var builder = new StringBuilder();
+
+            string? mostPreciseUnit = null;
+            foreach (var availableUnit in new[] { parser.TimeOffsetSettings.Milliseconds, parser.TimeOffsetSettings.Seconds, parser.TimeOffsetSettings.Minutes, parser.TimeOffsetSettings.Hours, parser.TimeOffsetSettings.Days, parser.TimeOffsetSettings.Weeks }) {
+                if (availableUnit == null) {
+                    continue;
+                }
+                mostPreciseUnit = availableUnit;
+                break;
+            }
+
+            if (parser.TimeOffsetSettings.Weeks != null && Math.Abs(timeSpan.TotalDays) >= 7) { 
+                var weeks = mostPreciseUnit == parser.TimeOffsetSettings.Weeks
+                    ? timeSpan.TotalDays / 7
+                    : Math.Truncate(timeSpan.TotalDays / 7);
+                builder.AppendFormat(parser.CultureInfo, "{0}{1}", weeks, parser.TimeOffsetSettings.Weeks);
+                timeSpan = timeSpan.Subtract(TimeSpan.FromDays(weeks * 7));
+            }
+
+            if (parser.TimeOffsetSettings.Days != null && Math.Abs(timeSpan.TotalDays) >= 1) {
+                var days = mostPreciseUnit == parser.TimeOffsetSettings.Days 
+                    ? timeSpan.TotalDays 
+                    : Math.Truncate(timeSpan.TotalDays);
+                if (builder.Length > 0) {
+                    builder.Append(" ");
+                }
+                builder.AppendFormat(parser.CultureInfo, "{0}{1}", days, parser.TimeOffsetSettings.Days);
+                timeSpan = timeSpan.Subtract(TimeSpan.FromDays(days));
+            }
+
+            if (parser.TimeOffsetSettings.Hours != null && Math.Abs(timeSpan.TotalHours) >= 1) {
+                var hours = mostPreciseUnit == parser.TimeOffsetSettings.Hours 
+                    ? timeSpan.TotalHours 
+                    : Math.Truncate(timeSpan.TotalHours);
+                if (builder.Length > 0) {
+                    builder.Append(" ");
+                }
+                builder.AppendFormat(parser.CultureInfo, "{0}{1}", hours, parser.TimeOffsetSettings.Hours);
+                timeSpan = timeSpan.Subtract(TimeSpan.FromHours(hours));
+            }
+
+            if (parser.TimeOffsetSettings.Minutes != null && Math.Abs(timeSpan.TotalMinutes) >= 1) {
+                var minutes = mostPreciseUnit == parser.TimeOffsetSettings.Minutes 
+                    ? timeSpan.TotalMinutes 
+                    : Math.Truncate(timeSpan.TotalMinutes);
+                if (builder.Length > 0) {
+                    builder.Append(" ");
+                }
+                builder.AppendFormat(parser.CultureInfo, "{0}{1}", minutes, parser.TimeOffsetSettings.Minutes);
+                timeSpan = timeSpan.Subtract(TimeSpan.FromMinutes(minutes));
+            }
+
+            if (parser.TimeOffsetSettings.Seconds != null && Math.Abs(timeSpan.TotalSeconds) >= 1) {
+                var seconds = mostPreciseUnit == parser.TimeOffsetSettings.Seconds
+                    ? timeSpan.TotalSeconds
+                    : Math.Truncate(timeSpan.TotalSeconds);
+                if (builder.Length > 0) {
+                    builder.Append(" ");
+                }
+                builder.AppendFormat(parser.CultureInfo, "{0}{1}", seconds, parser.TimeOffsetSettings.Seconds);
+                timeSpan = timeSpan.Subtract(TimeSpan.FromSeconds(seconds));
+            }
+
+            if (parser.TimeOffsetSettings.Milliseconds != null && Math.Abs(timeSpan.TotalMilliseconds) > 0) {
+                var milliseconds = timeSpan.TotalMilliseconds;
+                if (builder.Length > 0) {
+                    builder.Append(" ");
+                }
+                builder.AppendFormat(parser.CultureInfo, "{0}{1}", milliseconds, parser.TimeOffsetSettings.Milliseconds);
+            }
+
+            return builder.ToString();
+        }
+
+
+        /// <summary>
         /// Converts a <see cref="TimeSpan"/> to a Relativity duration string.
         /// </summary>
         /// <param name="parser">
@@ -150,16 +249,17 @@ namespace IntelligentPlant.Relativity {
         /// <param name="timeSpan">
         ///   The time span.
         /// </param>
+        /// <param name="unit">
+        ///   The time unit to use in the duration string. Specify <see cref="DurationUnitKind.Unspecified"/> 
+        ///   to return a duration string that uses composite units (e.g. <c>3H 15M</c>).
+        /// </param>
         /// <param name="decimalPlaces">
         ///   The number of decimal places to use when formatting the duration string. If greater 
         ///   than or equal to zero, the duration string will be rounded away from zero to the 
         ///   specified number of decimal places e.g. specifying one decimal place when a time 
         ///   span of <c>00:00:00.1234567</c> is specified will result in a duration string of 
-        ///   <c>123.5MS</c> being returned (or its equivalent localized value).
-        /// </param>
-        /// <param name="unit">
-        ///   The time unit to use in the duration string. Specify <see langword="null"/> to infer 
-        ///   a unit based on the magnitude of the <paramref name="timeSpan"/>.
+        ///   <c>123.5MS</c> being returned (or its equivalent localized value). This parameter is 
+        ///   ignored if <paramref name="unit"/> is <see cref="DurationUnitKind.Unspecified"/>.
         /// </param>
         /// <returns>
         ///   The duration string.
@@ -170,14 +270,6 @@ namespace IntelligentPlant.Relativity {
         /// <remarks>
         /// 
         /// <para>
-        ///   When <paramref name="unit"/> is <see langword="null"/>, the unit used in the 
-        ///   duration string is determined by the overall magnitude of the <see cref="TimeSpan"/>. 
-        ///   For example, a time span greater than or equal to one day will be formatted as whole 
-        ///   and fractional days, a time span greater than or equal to one hour will be formatted 
-        ///   as whole and fractional hours, and so on.
-        /// </para>
-        /// 
-        /// <para>
         ///   You can specify the number of decimal places to round the duration to using the 
         ///   <paramref name="decimalPlaces"/> parameter. When a value of zero or greater is 
         ///   specified, the duration string will be rounded away from zero to the specified 
@@ -186,56 +278,41 @@ namespace IntelligentPlant.Relativity {
         ///   <c>123.5MS</c> being returned (or its equivalent localized value).
         /// </para>
         /// 
+        /// <para>
+        ///   Note that the <paramref name="decimalPlaces"/> parameter is ignored if 
+        ///   <paramref name="unit"/> is <see cref="DurationUnitKind.Unspecified"/>.
+        /// </para>
+        /// 
         /// </remarks>
-        public static string ConvertToDuration(this IRelativityParser parser, TimeSpan timeSpan, int decimalPlaces = -1, string? unit = null) {
+        public static string ConvertToDuration(this IRelativityParser parser, TimeSpan timeSpan, DurationUnitKind unit, int decimalPlaces = -1) {
             if (parser == null) {
                 throw new ArgumentNullException(nameof(parser));
             }
 
-            if (unit != null) {
-                if (unit.Equals(parser.TimeOffsetSettings.Weeks, StringComparison.OrdinalIgnoreCase)) {
-                    return Format(timeSpan.TotalDays / 7, parser.TimeOffsetSettings.Weeks!);
-                }
-                else if (unit.Equals(parser.TimeOffsetSettings.Days, StringComparison.OrdinalIgnoreCase)) {
-                    return Format(timeSpan.TotalDays, parser.TimeOffsetSettings.Days!);
-                }
-                else if (unit.Equals(parser.TimeOffsetSettings.Hours, StringComparison.OrdinalIgnoreCase)) {
-                    return Format(timeSpan.TotalHours, parser.TimeOffsetSettings.Hours!);
-                }
-                else if (unit.Equals(parser.TimeOffsetSettings.Minutes, StringComparison.OrdinalIgnoreCase)) {
-                    return Format(timeSpan.TotalMinutes, parser.TimeOffsetSettings.Minutes!);
-                }
-                else if (unit.Equals(parser.TimeOffsetSettings.Seconds, StringComparison.OrdinalIgnoreCase)) {
-                    return Format(timeSpan.TotalSeconds, parser.TimeOffsetSettings.Seconds!);
-                }
-                else if (unit.Equals(parser.TimeOffsetSettings.Milliseconds, StringComparison.OrdinalIgnoreCase)) {
-                    return Format(timeSpan.TotalMilliseconds, parser.TimeOffsetSettings.Milliseconds!);
-                }
-
-                throw new InvalidOperationException("The specified time unit is not supported.");
+            if (unit == DurationUnitKind.Unspecified) {
+                return ConvertToDuration(parser, timeSpan);
             }
 
-            if (parser.TimeOffsetSettings.Days != null && Math.Abs(timeSpan.TotalDays) >= 1) {
-                return Format(timeSpan.TotalDays, parser.TimeOffsetSettings.Days);
+            if (unit == DurationUnitKind.Weeks) {
+                return Format(timeSpan.TotalDays / 7, parser.TimeOffsetSettings.Weeks!);
+            }
+            else if (unit == DurationUnitKind.Days) {
+                return Format(timeSpan.TotalDays, parser.TimeOffsetSettings.Days!);
+            }
+            else if (unit == DurationUnitKind.Hours) {
+                return Format(timeSpan.TotalHours, parser.TimeOffsetSettings.Hours!);
+            }
+            else if (unit == DurationUnitKind.Minutes) {
+                return Format(timeSpan.TotalMinutes, parser.TimeOffsetSettings.Minutes!);
+            }
+            else if (unit == DurationUnitKind.Seconds) {
+                return Format(timeSpan.TotalSeconds, parser.TimeOffsetSettings.Seconds!);
+            }
+            else if (unit == DurationUnitKind.Milliseconds) {
+                return Format(timeSpan.TotalMilliseconds, parser.TimeOffsetSettings.Milliseconds!);
             }
 
-            if (parser.TimeOffsetSettings.Hours != null && Math.Abs(timeSpan.TotalHours) >= 1) {
-                return Format(timeSpan.TotalHours, parser.TimeOffsetSettings.Hours);
-            }
-
-            if (parser.TimeOffsetSettings.Minutes != null && Math.Abs(timeSpan.TotalMinutes) >= 1) {
-                return Format(timeSpan.TotalMinutes, parser.TimeOffsetSettings.Minutes);
-            }
-
-            if (parser.TimeOffsetSettings.Seconds != null && Math.Abs(timeSpan.Seconds) >= 1) {
-                return Format(timeSpan.TotalSeconds, parser.TimeOffsetSettings.Seconds);
-            }
-
-            if (parser.TimeOffsetSettings.Milliseconds != null) {
-                return Format(timeSpan.TotalMilliseconds, parser.TimeOffsetSettings.Milliseconds);
-            }
-
-            throw new InvalidOperationException("Could not determine the unit to use for the formatted duration string.");
+            throw new InvalidOperationException("The specified time unit is not supported.");
 
             string Format(double value, string unit) {
                 return string.Format(parser.CultureInfo, "{0}{1}", RoundAwayFromZeroIfRequired(value), unit);
@@ -250,6 +327,180 @@ namespace IntelligentPlant.Relativity {
                     ? Math.Ceiling(value * factor) / factor
                     : Math.Floor(value * factor) / factor;
             }
+        }
+
+
+        /// <summary>
+        /// Gets the symbol for the specified relative time origin kind.
+        /// </summary>
+        /// <param name="settings">
+        ///   The base time settings.
+        /// </param>
+        /// <param name="origin">
+        ///   The relative time origin kind.
+        /// </param>
+        /// <returns>
+        ///   The symbol for the specified relative time origin kind, or <see langword="null"/> if 
+        ///   no symbol is available.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="settings"/> is <see langword="null"/>.
+        /// </exception>
+        public static string? GetSymbol(this RelativityBaseTimeSettings settings, RelativeTimeOriginKind origin) {
+            if (settings == null) {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            return origin switch {
+                RelativeTimeOriginKind.Now => settings.Now ?? settings.NowAlt,
+                RelativeTimeOriginKind.CurrentSecond => settings.CurrentSecond,
+                RelativeTimeOriginKind.CurrentMinute => settings.CurrentMinute,
+                RelativeTimeOriginKind.CurrentHour => settings.CurrentHour,
+                RelativeTimeOriginKind.CurrentDay => settings.CurrentDay,
+                RelativeTimeOriginKind.CurrentWeek => settings.CurrentWeek,
+                RelativeTimeOriginKind.CurrentMonth => settings.CurrentMonth,
+                RelativeTimeOriginKind.CurrentYear => settings.CurrentYear,
+                _ => null
+            };
+        }
+
+
+        /// <summary>
+        /// Gets the symbol for the specified relative time origin type.
+        /// </summary>
+        /// <param name="parser">
+        ///   The parser
+        /// </param>
+        /// <param name="origin">
+        ///   The relative time origin type.
+        /// </param>
+        /// <returns>
+        ///   The symbol for the specified relative time origin kind, or <see langword="null"/> if 
+        ///   no symbol is available.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="parser"/> is <see langword="null"/>.
+        /// </exception>
+        public static string? GetSymbol(this IRelativityParser parser, RelativeTimeOriginKind origin) => parser?.BaseTimeSettings.GetSymbol(origin);
+
+
+        /// <summary>
+        /// Gets the symbol for the specified duration unit type.
+        /// </summary>
+        /// <param name="settings">
+        ///   The base time settings.
+        /// </param>
+        /// <param name="unit">
+        ///   The duration unit type.
+        /// </param>
+        /// <returns>
+        ///   The symbol for the specified duration unit type, or <see langword="null"/> if 
+        ///   no symbol is available.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="settings"/> is <see langword="null"/>.
+        /// </exception>
+        public static string? GetSymbol(this RelativityTimeOffsetSettings settings, DurationUnitKind unit) {
+            if (settings == null) {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            return unit switch {
+                DurationUnitKind.Milliseconds => settings.Milliseconds,
+                DurationUnitKind.Seconds => settings.Seconds,
+                DurationUnitKind.Minutes => settings.Minutes,
+                DurationUnitKind.Hours => settings.Hours,
+                DurationUnitKind.Days => settings.Days,
+                DurationUnitKind.Weeks => settings.Weeks,
+                _ => null
+            };
+        }
+
+
+        /// <summary>
+        /// Gets the symbol for the specified duration unit type.
+        /// </summary>
+        /// <param name="parser">
+        ///   The parser.
+        /// </param>
+        /// <param name="unit">
+        ///   The duration unit type.
+        /// </param>
+        /// <returns>
+        ///   The symbol for the specified duration unit type, or <see langword="null"/> if 
+        ///   no symbol is available.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="parser"/> is <see langword="null"/>.
+        /// </exception>
+        public static string? GetSymbol(this IRelativityParser parser, DurationUnitKind unit) => parser?.TimeOffsetSettings.GetSymbol(unit);
+
+
+        /// <summary>
+        /// Gets the symbol for the specified relative time offset unit type.
+        /// </summary>
+        /// <param name="settings">
+        ///   The base time settings.
+        /// </param>
+        /// <param name="unit">
+        ///   The relative time offset unit type.
+        /// </param>
+        /// <returns>
+        ///   The symbol for the specified relative time offset unit type, or <see langword="null"/> 
+        ///   if no symbol is available.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="settings"/> is <see langword="null"/>.
+        /// </exception>
+        public static string? GetSymbol(this RelativityTimeOffsetSettings settings, RelativeTimeOffsetUnitKind unit) {
+            if (settings == null) {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            return unit switch {
+                RelativeTimeOffsetUnitKind.Milliseconds => settings.Milliseconds,
+                RelativeTimeOffsetUnitKind.Seconds => settings.Seconds,
+                RelativeTimeOffsetUnitKind.Minutes => settings.Minutes,
+                RelativeTimeOffsetUnitKind.Hours => settings.Hours,
+                RelativeTimeOffsetUnitKind.Days => settings.Days,
+                RelativeTimeOffsetUnitKind.Weeks => settings.Weeks,
+                RelativeTimeOffsetUnitKind.Months => settings.Months,
+                RelativeTimeOffsetUnitKind.Years => settings.Years,
+                _ => null
+            };
+        }
+
+
+        /// <summary>
+        /// Gets the symbol for the specified relative time offset unit type.
+        /// </summary>
+        /// <param name="parser">
+        ///   The base time settings.
+        /// </param>
+        /// <param name="unit">
+        ///   The relative time offset unit type.
+        /// </param>
+        /// <returns>
+        ///   The symbol for the specified relative time offset unit type, or <see langword="null"/> 
+        ///   if no symbol is available.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="parser"/> is <see langword="null"/>.
+        /// </exception>
+        public static string? GetSymbol(this IRelativityParser parser, RelativeTimeOffsetUnitKind unit) => parser?.TimeOffsetSettings.GetSymbol(unit);
+
+
+        internal static string CreateEmptyDurationString(this IRelativityParser parser) {
+            var units = 
+                parser.TimeOffsetSettings.GetSymbol(DurationUnitKind.Milliseconds) ??
+                parser.TimeOffsetSettings.GetSymbol(DurationUnitKind.Seconds) ??
+                parser.TimeOffsetSettings.GetSymbol(DurationUnitKind.Minutes) ??
+                parser.TimeOffsetSettings.GetSymbol(DurationUnitKind.Hours) ??
+                parser.TimeOffsetSettings.GetSymbol(DurationUnitKind.Days) ??
+                parser.TimeOffsetSettings.GetSymbol(DurationUnitKind.Weeks) ??
+                throw new InvalidOperationException("No duration components are enabled.");
+
+            return string.Format(parser.CultureInfo, "{0}{1}", 0, units);
         }
 
     }

--- a/src/IntelligentPlant.Relativity/TimeSpanExtensions.cs
+++ b/src/IntelligentPlant.Relativity/TimeSpanExtensions.cs
@@ -1,0 +1,56 @@
+﻿using System;
+
+namespace IntelligentPlant.Relativity {
+
+    /// <summary>
+    /// Extensions for <see cref="TimeSpan"/>.
+    /// </summary>
+    public static class TimeSpanExtensions {
+
+        /// <summary>
+        /// Converts the <see cref="TimeSpan"/> to a Relativity duration string.
+        /// </summary>
+        /// <param name="value">
+        ///   The <see cref="TimeSpan"/>.
+        /// </param>
+        /// <param name="parser">
+        ///   The <see cref="IRelativityParser"/> to use when converting the <see cref="TimeSpan"/>. 
+        ///   Specify <see langword="null"/> to use <see cref="RelativityParser.InvariantUtc"/>.
+        /// </param>
+        /// <returns>
+        ///   A Relativity duration string that represents the <see cref="TimeSpan"/>.
+        /// </returns>
+        public static string ToDurationString(this TimeSpan value, IRelativityParser? parser = null) {
+            return (parser ?? RelativityParser.InvariantUtc).ConvertToDuration(value);
+        }
+
+
+        /// <summary>
+        /// Converts the <see cref="TimeSpan"/> to a Relativity duration string that uses the specified time unit.
+        /// </summary>
+        /// <param name="value">
+        ///   The <see cref="TimeSpan"/>.
+        /// </param>
+        /// <param name="parser">
+        ///   The <see cref="IRelativityParser"/> to use when converting the <see cref="TimeSpan"/>. 
+        ///   Specify <see langword="null"/> to use <see cref="RelativityParser.InvariantUtc"/>.
+        /// </param>
+        /// <param name="unit">
+        ///   The time unit to use when converting the <see cref="TimeSpan"/>. You can specify any 
+        ///   valid duration unit defined by the <paramref name="parser"/>.
+        /// </param>
+        /// <param name="decimalPlaces">
+        ///   The number of decimal places to use when converting the <see cref="TimeSpan"/>. For 
+        ///   example, specifying one decimal place when a time span of <c>00:00:00.1234567</c> is 
+        ///   specified will result in a duration string of <c>123.5MS</c> being returned (or its 
+        ///   equivalent localized value).
+        /// </param>
+        /// <returns>
+        ///   A Relativity duration string that represents the <see cref="TimeSpan"/>.
+        /// </returns>
+        public static string ToDurationString(this TimeSpan value, IRelativityParser? parser, DurationUnitKind unit, int decimalPlaces = -1) { 
+            return (parser ?? RelativityParser.InvariantUtc).ConvertToDuration(value, unit, decimalPlaces);
+        }
+
+    }
+}

--- a/test/IntelligentPlant.Relativity.Test/DateTimeParsingTests.cs
+++ b/test/IntelligentPlant.Relativity.Test/DateTimeParsingTests.cs
@@ -410,5 +410,33 @@ namespace IntelligentPlant.Relativity.Test {
             Assert.AreEqual(123.456 * 7, parsed.TotalDays);
         }
 
+
+        [DataTestMethod]
+        [DataRow("1w 3d 14h 27m 59s 251ms", "10.14:27:59.251")]
+        [DataRow("   1w 3d 14h 27m 59s 251ms      ", "10.14:27:59.251")]
+        [DataRow("0.5d 1h", "13:00:00")]
+        [DataRow("2h37.6s", "02:00:37.600")]
+        [DataRow("1d0h15m0s3ms", "1.00:15:00.003")]
+        public void ShouldConvertCompositeDuration(string expression, string timeSpanLiteral) {
+            var parser = RelativityParser.InvariantUtc;
+
+            var timeSpanExpected = TimeSpan.Parse(timeSpanLiteral);
+            var timeSpanActual = parser.ConvertToTimeSpan(expression);
+
+            Assert.AreEqual(timeSpanExpected, timeSpanActual);
+        }
+
+
+        [TestMethod]
+        public void ShouldParseRelativeTimeWithCompositeOffset() {
+            var parser = RelativityParser.InvariantUtc;
+
+            var baseTime = DateTime.UtcNow;
+            var parsedDate = parser.ConvertToUtcDateTime("NOW - 4Y 3MO 6D 15S 243MS", baseTime);
+            var expectedDate = baseTime.AddYears(-4).AddMonths(-3).AddDays(-6).AddSeconds(-15).AddMilliseconds(-243);
+
+            Assert.AreEqual(expectedDate, parsedDate);
+        }
+
     }
 }

--- a/test/IntelligentPlant.Relativity.Test/DurationBuilderTests.cs
+++ b/test/IntelligentPlant.Relativity.Test/DurationBuilderTests.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace IntelligentPlant.Relativity.Test {
+
+    [TestClass]
+    public class DurationBuilderTests {
+
+        [TestMethod]
+        public void ShouldBuildDurationString() {
+            var duration = new DurationBuilder()
+                .Weeks(1)
+                .Days(2)
+                .Hours(3)
+                .Minutes(4)
+                .Seconds(5)
+                .Milliseconds(6)
+                .Build();
+
+            Assert.AreEqual("1W 2D 3H 4M 5S 6MS", duration);
+        }
+
+
+        [TestMethod]
+        public void ShouldBuildEmptyDurationString() {
+            var duration = new DurationBuilder()
+                .Build();
+
+            Assert.AreEqual("0MS", duration);
+        }
+
+
+        [TestMethod]
+        public void ShouldIgnoreZeroUnits() {
+            var duration = new DurationBuilder()
+                .Weeks(0)
+                .Days(2)
+                .Hours(3)
+                .Minutes(0)
+                .Seconds(0)
+                .Milliseconds(6)
+                .Build();
+
+            Assert.AreEqual("2D 3H 6MS", duration);
+        }
+
+    }
+
+}

--- a/test/IntelligentPlant.Relativity.Test/TimeSpanConversionTests.cs
+++ b/test/IntelligentPlant.Relativity.Test/TimeSpanConversionTests.cs
@@ -8,50 +8,53 @@ namespace IntelligentPlant.Relativity.Test {
     public class TimeSpanConversionTests {
 
         [DataTestMethod]
-        [DataRow("1.18:00:00", 2, "1.75D")]
-        [DataRow("1.18:00:00", 1, "1.8D")]
-        [DataRow("1.18:00:00", 0, "2D")]
-        [DataRow("18:30:00", 1, "18.5H")]
-        [DataRow("18:30:00", 0, "19H")]
-        [DataRow("00:15:45", 2, "15.75M")]
-        [DataRow("00:15:45", 1, "15.8M")]
-        [DataRow("00:15:45", 0, "16M")]
-        [DataRow("00:00:01.250", 2, "1.25S")]
-        [DataRow("00:00:01.250", 1, "1.3S")]
-        [DataRow("00:00:01.250", 0, "2S")]
-        [DataRow("00:00:00.2345678", -1, "234.5678MS")]
-        [DataRow("00:00:00.2345768", 0, "235MS")]
-        [DataRow("-1.18:00:00", 2, "-1.75D")]
-        [DataRow("-1.18:00:00", 1, "-1.8D")]
-        [DataRow("-1.18:00:00", 0, "-2D")]
-        [DataRow("-18:30:00", 1, "-18.5H")]
-        [DataRow("-18:30:00", 0, "-19H")]
-        [DataRow("-00:15:45", 2, "-15.75M")]
-        [DataRow("-00:15:45", 1, "-15.8M")]
-        [DataRow("-00:15:45", 0, "-16M")]
-        [DataRow("-00:00:01.250", 2, "-1.25S")]
-        [DataRow("-00:00:01.250", 1, "-1.3S")]
-        [DataRow("-00:00:01.250", 0, "-2S")]
-        [DataRow("-00:00:00.2345678", -1, "-234.5678MS")]
-        [DataRow("-00:00:00.2345768", 0, "-235MS")]
-        public void ShouldConvertToDurationWithSpecifiedPrecision(string timeSpanLiteral, int decimalPlaces, string expectedDuration) {
+        [DataRow("1.18:00:00", DurationUnitKind.Days, 2, "1.75D")]
+        [DataRow("1.18:00:00", DurationUnitKind.Days, 1, "1.8D")]
+        [DataRow("1.18:00:00", DurationUnitKind.Days, 0, "2D")]
+        [DataRow("18:30:00", DurationUnitKind.Hours, 1, "18.5H")]
+        [DataRow("18:30:00", DurationUnitKind.Hours, 0, "19H")]
+        [DataRow("00:15:45", DurationUnitKind.Minutes, 2, "15.75M")]
+        [DataRow("00:15:45", DurationUnitKind.Minutes, 1, "15.8M")]
+        [DataRow("00:15:45", DurationUnitKind.Minutes, 0, "16M")]
+        [DataRow("00:00:01.250", DurationUnitKind.Seconds, 2, "1.25S")]
+        [DataRow("00:00:01.250", DurationUnitKind.Seconds, 1, "1.3S")]
+        [DataRow("00:00:01.250", DurationUnitKind.Seconds, 0, "2S")]
+        [DataRow("00:00:00.2345678", DurationUnitKind.Milliseconds, -1, "234.5678MS")]
+        [DataRow("00:00:00.2345768", DurationUnitKind.Milliseconds, 0, "235MS")]
+        [DataRow("-1.18:00:00", DurationUnitKind.Days, 2, "-1.75D")]
+        [DataRow("-1.18:00:00", DurationUnitKind.Days, 1, "-1.8D")]
+        [DataRow("-1.18:00:00", DurationUnitKind.Days, 0, "-2D")]
+        [DataRow("-18:30:00", DurationUnitKind.Hours, 1, "-18.5H")]
+        [DataRow("-18:30:00", DurationUnitKind.Hours, 0, "-19H")]
+        [DataRow("-00:15:45", DurationUnitKind.Minutes, 2, "-15.75M")]
+        [DataRow("-00:15:45", DurationUnitKind.Minutes, 1, "-15.8M")]
+        [DataRow("-00:15:45", DurationUnitKind.Minutes, 0, "-16M")]
+        [DataRow("-00:00:01.250", DurationUnitKind.Seconds, 2, "-1.25S")]
+        [DataRow("-00:00:01.250", DurationUnitKind.Seconds, 1, "-1.3S")]
+        [DataRow("-00:00:01.250", DurationUnitKind.Seconds, 0, "-2S")]
+        [DataRow("-00:00:00.2345678", DurationUnitKind.Milliseconds, -1, "-234.5678MS")]
+        [DataRow("-00:00:00.2345768", DurationUnitKind.Milliseconds, 0, "-235MS")]
+        public void ShouldConvertToDurationWithSpecifiedPrecision(string timeSpanLiteral, DurationUnitKind unit, int decimalPlaces, string expectedDuration) {
             var timeSpan = TimeSpan.Parse(timeSpanLiteral);
-            var duration = RelativityParser.InvariantUtc.ConvertToDuration(timeSpan, decimalPlaces: decimalPlaces);
+            var duration = RelativityParser.InvariantUtc.ConvertToDuration(timeSpan, unit, decimalPlaces);
             Assert.AreEqual(expectedDuration, duration);
         }
 
 
         [DataTestMethod]
-        [DataRow("1.18:00:00", "H", "42H")]
-        [DataRow("01:30:00", "M", "90M")]
-        [DataRow("00:05:30", "S", "330S")]
-        [DataRow("00:00:01.500", "MS", "1500MS")]
-        public void ShouldConvertToDurationWithSpecifiedUnits(string timeSpanLiteral, string unit, string expectedDuration) {
+        [DataRow("1.18:00:00", DurationUnitKind.Unspecified, "1D 18H")]
+        [DataRow("1.18:00:00", DurationUnitKind.Hours, "42H")]
+        [DataRow("01:30:00", DurationUnitKind.Unspecified, "1H 30M")]
+        [DataRow("01:30:00", DurationUnitKind.Minutes, "90M")]
+        [DataRow("00:05:30", DurationUnitKind.Unspecified, "5M 30S")]
+        [DataRow("00:05:30", DurationUnitKind.Seconds, "330S")]
+        [DataRow("00:00:01.500", DurationUnitKind.Unspecified, "1S 500MS")]
+        [DataRow("00:00:01.500", DurationUnitKind.Milliseconds, "1500MS")]
+        public void ShouldConvertToDurationWithSpecifiedUnits(string timeSpanLiteral, DurationUnitKind unit, string expectedDuration) {
             var timeSpan = TimeSpan.Parse(timeSpanLiteral);
             var duration = RelativityParser.InvariantUtc.ConvertToDuration(timeSpan, unit: unit);
             Assert.AreEqual(expectedDuration, duration);
         }
-
 
     }
 


### PR DESCRIPTION
This PR contains breaking changes.

The PR adds support for specifying durations and relative times using composite time units. For example, 90 minutes before the current time can now be specified as `NOW - 1H 30M` in addition to `NOW - 90M` or `NOW - 1.5H`.

There are breaking changes to the `ConvertToDuration` extension method for `IRelativityParser`, so the PR also bumps the major version.